### PR TITLE
Improve network pressure detection and congestion mitigation

### DIFF
--- a/balancer/controller/network.py
+++ b/balancer/controller/network.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import glob
+import re
 # [SECURITY REVIEW]: All subprocess calls in this module use list-based arguments
 # with shell=False (default). No untrusted shell execution or string
 # concatenation is performed. All inputs are internally validated.
@@ -11,6 +13,7 @@ import time
 from utils.logger import logger
 from config.config import b_config
 from monitor import NetworkMonitor
+from monitor.network_pressure import publish_network_pressure_snapshot
 from monitor.system_info import _get_network_static_info
 from utils import app_utils
 
@@ -27,6 +30,31 @@ NETWORK_PRIORITIES = ("critical", "high", "low", "system")
 # we pick r2q per NIC from its total bandwidth rather than hard-coding it — this
 # keeps quantum in range whether the link is 100Mbit or 10Gbit.
 _TARGET_HTB_QUANTUM_BYTES = 100000
+
+_DEFAULT_NETWORK_PPS_POLICY = {
+    "enable_fq_codel": True,
+    "enable_rps_escalation": True,
+    "enable_netdev_budget_bump": False,
+    "collective_harm_threshold": 0.5,
+    "pps_window_sec": 5.0,
+}
+
+_PPS_POLICY_BOOL_KEYS = {
+    "enable_fq_codel",
+    "enable_rps_escalation",
+    "enable_netdev_budget_bump",
+}
+
+_PPS_POLICY_FLOAT_KEYS = {
+    "app_pps_high",
+    "collective_harm_threshold",
+    "pps_window_sec",
+}
+
+_PPS_POLICY_INT_KEYS = {
+    "pps_cap_rate",
+    "pps_cap_burst",
+}
 
 
 def compute_r2q(total_bw_kbit):
@@ -50,17 +78,25 @@ class _NicShaper:
 
     Each controlled interface owns an independent tc tree: the physical device
     plus a paired IFB device (for ingress shaping), a unique tc handle, its own
-    bandwidth budget and NetworkMonitor, and per-direction throttle stages and
-    class ids. Holding one of these per NIC is what makes multi-NIC support
-    possible — the controller simply iterates over a list of shapers.
+    bandwidth budget, a reference to its NIC's NetworkMonitor (owned by the
+    monitoring layer), and per-direction throttle stages and class ids. Holding
+    one of these per NIC is what makes multi-NIC support possible — the
+    controller simply iterates over a list of shapers.
+
+    A shaper is built only for NICs with a known link speed; monitoring runs for
+    every usable NIC regardless (see NetworkController.monitors).
     """
 
-    def __init__(self, dev, ifb_dev, handle_id, total_bw):
+    def __init__(self, dev, ifb_dev, handle_id, total_bw, monitor):
         self.dev = dev
         self.ifb_dev = ifb_dev
         self.handle_id = handle_id
         self.total_bw = total_bw
-        self.monitor = NetworkMonitor(dev, total_bw)
+        # Shared with NetworkController.monitors[dev]: the monitor is owned by the
+        # monitoring layer (built for every usable NIC) and merely referenced here so
+        # tc-class-stats collection can reuse the same sampling object. A shaper never
+        # constructs its own monitor -- monitoring must run even for un-shapeable NICs.
+        self.monitor = monitor
         # Per-direction throttle stage (0 == unlimited) and cooldown timestamps.
         self.tx_limit_stage = 0
         self.rx_limit_stage = 0
@@ -85,6 +121,14 @@ class NetworkController:
         self.mark_pool = set(hex(i) for i in range(0x1000, 0x2000))
         self.app_mark_map = {}
         self.app_filter_info = {}
+        self.app_pps_samples = {}
+        self.app_pps_rates = {}
+        self.app_pps_caps = {}
+        self._app_pps_police_supported = None
+        self._rx_escalation_state = {}
+        # Last TX pps-gate outcome we logged, so a sustained flood logs on transitions
+        # instead of every eval cycle.
+        self._last_pps_gate_signature = None
         # Set when the API persists new network config; the monitor thread picks
         # this up at the top of its next cycle and rebuilds, so all tc mutations
         # stay on a single thread (no locking around live tc operations).
@@ -92,9 +136,12 @@ class NetworkController:
 
         self._load_config_state()
 
-        # Build one shaper per existing configured interface.
+        # Monitoring is built for every usable NIC; shaping only for the subset with a
+        # known link speed. Monitors must exist before shapers -- each shaper references
+        # its NIC's monitor from self.monitors.
+        self.monitors = self._build_monitors()
         self.shapers = self._build_shapers()
-        if not self.shapers:
+        if not self.monitors:
             logger.warning("No usable network interface found; disable network sampling/control.")
             self.enable_network_control = False
 
@@ -124,7 +171,7 @@ class NetworkController:
             config_network_bw = {
                 "critical": {"min": 0.6, "max": 0.9},
                 "high": {"min": 0.3, "max": 0.8},
-                "low": {"min": 0.1, "max": 0.3},
+                "low": {"min": 0.1, "max": 1.0},
                 "system": {"min": 0.05, "max": 0.1},
             }
         burst_map = getattr(self.config, "network_burst_map", None)
@@ -137,6 +184,32 @@ class NetworkController:
             }
         self.config_network_bw = config_network_bw
         self.network_burst_map = burst_map
+        self.network_pps_policy = self._normalized_pps_policy(
+            getattr(self.config, "network_pps_policy", None)
+        )
+        self.enable_app_pps_police = bool(
+            getattr(self.config, "enable_app_pps_police", False)
+        )
+
+    def _normalized_pps_policy(self, raw_policy):
+        policy = dict(_DEFAULT_NETWORK_PPS_POLICY)
+        if not isinstance(raw_policy, dict):
+            return policy
+
+        for key, value in raw_policy.items():
+            if key in _PPS_POLICY_BOOL_KEYS:
+                policy[key] = bool(value)
+            elif key in _PPS_POLICY_FLOAT_KEYS:
+                try:
+                    policy[key] = float(value)
+                except (TypeError, ValueError):
+                    continue
+            elif key in _PPS_POLICY_INT_KEYS:
+                try:
+                    policy[key] = max(1, int(value))
+                except (TypeError, ValueError):
+                    continue
+        return policy
 
     def request_reload(self):
         """Signal the monitor thread to rebuild network shaping from current config.
@@ -163,26 +236,35 @@ class NetworkController:
         # Reset per-app and mark state; apps get re-added on the next cycle.
         self.app_mark_map = {}
         self.app_filter_info = {}
+        self.app_pps_samples = {}
+        self.app_pps_rates = {}
+        self.app_pps_caps = {}
+        self._app_pps_police_supported = None
+        self._last_pps_gate_signature = None
         self.mark_pool = set(hex(i) for i in range(0x1000, 0x2000))
 
         # Re-read config and re-detect interfaces.
         self._load_config_state()
+        self.monitors = self._build_monitors()
         self.shapers = self._build_shapers()
-        if not self.shapers:
+        if not self.monitors:
             logger.warning("No usable network interface found after reload; network control disabled.")
             self.enable_network_control = False
             return
-        self.setup_tc_classes_and_filters()
-        logger.info("Network configuration reload complete (%d interface(s) active).", len(self.shapers))
+        if self.shapers:
+            self.setup_tc_classes_and_filters()
+        logger.info("Network configuration reload complete (%d monitored, %d shaped).",
+                    len(self.monitors), len(self.shapers))
 
     # ------------------------------------------------------------------ config
 
     def _resolve_nic_specs(self):
         """Return the NICs to shape as a list of (name,) tuples.
 
-        A configured ``network_interfaces`` list is the user's explicit
-        selection. When no selection has ever been saved, all usable physical
-        NICs are selected automatically. Bandwidth is always system-detected.
+        A configured ``network_interfaces`` list is the user's explicit TC
+        selection. When TC is disabled and that list is empty, all usable
+        physical NICs are sampled for pressure monitoring only. Bandwidth is
+        always system-detected.
         """
         nics = getattr(self.config, "network_interfaces", None)
         if nics is not None:
@@ -199,7 +281,9 @@ class NetworkController:
                     continue
                 seen.add(name)
                 specs.append((name, None))
-            return specs
+            if specs or self.enable_network_control:
+                return specs
+            logger.info("No TC interface selected; auto-detecting NICs for network pressure monitoring.")
 
         detected = _get_network_static_info().get("valid_nics", [])
         names = [nic.get("name") for nic in detected if isinstance(nic, dict) and nic.get("name")]
@@ -225,31 +309,84 @@ class NetworkController:
     def _bandwidth_for(self, iface):
         """Detect the bandwidth (kbit/s) for a given interface.
 
-        Returns the link speed read from sysfs. Returns 0 when the speed can't
-        be determined (link down, WiFi/virtual driver). The caller treats 0 as
-        "not shapeable" and skips the NIC — bandwidth is never user-configured.
+        Prefer the sysfs speed, then fall back to the static network inventory
+        used by the About and Network views. This keeps pressure monitoring
+        available when a driver exposes its speed through psutil but not the
+        sysfs speed file. Returns 0 only when neither source knows the speed.
         """
         detected = self._detect_link_speed_kbit(iface)
         if detected:
             logger.info("Interface '%s': detected link speed %d kbit/s.", iface, detected)
-        return detected
+            return detected
 
-    def _build_shapers(self):
-        shapers = []
-        idx = 0
+        valid_nics = _get_network_static_info().get("valid_nics", [])
+        for nic in valid_nics:
+            if not isinstance(nic, dict) or nic.get("name") != iface:
+                continue
+            try:
+                speed_mbps = int(nic.get("speed_mbps", 0))
+            except (TypeError, ValueError):
+                break
+            if speed_mbps > 0:
+                fallback = speed_mbps * 1000
+                logger.info(
+                    "Interface '%s': using static inventory speed %d kbit/s for pressure monitoring.",
+                    iface, fallback,
+                )
+                return fallback
+            break
+        return 0
+
+    def _build_monitors(self):
+        """One NetworkMonitor per *usable* NIC, keyed by device name.
+
+        Monitoring is independent of shaping: a NIC is monitored as long as it exists
+        and is not a bond/bridge slave. Link speed is NOT required -- NetworkMonitor
+        accepts ``bandwidth_kbit=0`` and scores pps/congestion only, so a NIC whose
+        speed the driver never reports still produces a live pressure snapshot for the
+        dashboard. Bandwidth only gates *shaping* (see :meth:`_build_shapers`).
+        """
+        monitors = {}
         for iface, _unused in self._resolve_nic_specs():
             if not os.path.exists(f"/sys/class/net/{iface}"):
                 logger.warning(f"Network interface '{iface}' does not exist; skipping.")
                 continue
+            # Enslaved NICs (bond/team slaves, bridge ports) expose a `master` symlink; the
+            # master carries the traffic, so both shaping and pressure attribution belong to
+            # the master. Skip even if explicitly configured (auto-detect already filters
+            # these via _is_candidate_interface).
+            if os.path.islink(f"/sys/class/net/{iface}/master"):
+                master = os.path.basename(os.readlink(f"/sys/class/net/{iface}/master"))
+                logger.warning(
+                    "Skipping interface '%s': it is enslaved to '%s' (bond/bridge). "
+                    "Configure the master interface instead.", iface, master)
+                continue
+            if iface in monitors:
+                continue
+            total_bw = self._bandwidth_for(iface)
+            monitors[iface] = NetworkMonitor(iface, total_bw)
+            logger.info("Network pressure monitoring enabled on '%s' (bandwidth=%s).",
+                        iface, f"{total_bw} kbit/s" if total_bw > 0 else "unknown")
+        return monitors
+
+    def _build_shapers(self):
+        """One _NicShaper per *shapeable* NIC (subset of self.monitors with a known link
+        speed). Bandwidth-unknown NICs are monitored but not shaped -- TC needs the link
+        rate to size classes. Each shaper references its NIC's monitor from self.monitors.
+        """
+        shapers = []
+        idx = 0
+        for iface, monitor in self.monitors.items():
             total_bw = self._bandwidth_for(iface)
             if total_bw <= 0:
                 logger.warning(
-                    "Skipping interface '%s': link speed unavailable "
-                    "(link down or driver does not report speed).", iface)
+                    "Interface '%s': link speed unavailable "
+                    "(link down or driver does not report speed); "
+                    "monitoring only, no traffic shaping.", iface)
                 continue
             handle_id = self.base_handle_id + 2 * idx
             ifb_dev = f"ifb{idx}"
-            shapers.append(_NicShaper(iface, ifb_dev, handle_id, total_bw))
+            shapers.append(_NicShaper(iface, ifb_dev, handle_id, total_bw, monitor))
             logger.info(f"Network shaping enabled on '{iface}' (ifb={ifb_dev}, "
                         f"handle={handle_id}, bandwidth={total_bw} kbit/s)")
             idx += 1
@@ -373,6 +510,7 @@ class NetworkController:
         info = self.app_filter_info.get(app_id)
         if not info:
             return
+        self._clear_app_pps_cap(app_id)
         mark = info.get("mark")
         cgroup_paths = info.get("cgroup_paths") or []
         if isinstance(cgroup_paths, str):
@@ -447,6 +585,8 @@ class NetworkController:
 
                 classid_egress = self._get_classid(handle_id, key)
                 subprocess.run(["tc", "class", "add", "dev", dev, "parent", f"{handle_id}:1", "classid", classid_egress, "htb", "rate", f"{min_bw}kbit", "ceil", f"{max_bw}kbit", "burst", burst, "cburst", burst], check=False)
+                if self.network_pps_policy.get("enable_fq_codel", True):
+                    subprocess.run(["tc", "qdisc", "add", "dev", dev, "parent", classid_egress, "handle", self._fq_codel_handle(handle_id, key), "fq_codel"], check=False)
 
                 classid_ifb = self._get_classid(handle_id + 1, key)
                 subprocess.run(["tc", "class", "add", "dev", IFB_DEV, "parent", f"{handle_id+1}:1", "classid", classid_ifb, "htb", "rate", f"{min_bw}kbit", "ceil", f"{max_bw}kbit", "burst", burst, "cburst", burst], check=False)
@@ -501,6 +641,10 @@ class NetworkController:
         mapping = {"critical": 10, "high": 20, "low": 30, "system": 5}
         num = mapping[normalize_net_priority(priority)]
         return f"{handle}:{num}"
+
+    def _fq_codel_handle(self, handle, priority):
+        mapping = {"critical": 10, "high": 20, "low": 30, "system": 5}
+        return f"{handle}{mapping[normalize_net_priority(priority)]:02d}:"
 
     def _get_class_bandwidth(self, priority, total_bw):
         # Tiers are stored as ratios (0..1) of total_bw; convert to kbit/s here.
@@ -637,18 +781,303 @@ class NetworkController:
         time_since_recover = time.time() - last_recover_time
         return time_since_limit > cooldown and time_since_recover > cooldown
 
+    def _tier_rank(self, priority):
+        return {"low": 1, "high": 2, "critical": 3, "system": 4}.get(
+            normalize_net_priority(priority), 1
+        )
+
+    def _read_app_mark_packet_counts(self):
+        result = subprocess.run(
+            ["iptables", "-t", "mangle", "-nvxL", "OUTPUT"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if getattr(result, "returncode", 0) != 0:
+            return {}
+
+        counts_by_mark = {}
+        for line in getattr(result, "stdout", "").splitlines():
+            parts = line.split()
+            if len(parts) < 2 or not parts[0].isdigit():
+                continue
+            match = re.search(r"MARK\s+set\s+(0x[0-9a-fA-F]+|\d+)", line)
+            if not match:
+                continue
+            mark_value = int(match.group(1), 0)
+            counts_by_mark[mark_value] = counts_by_mark.get(mark_value, 0) + int(parts[0])
+        return counts_by_mark
+
+    def _sample_app_pps(self):
+        now = time.time()
+        counts_by_mark = self._read_app_mark_packet_counts()
+        pps_rates = {}
+        max_window = max(0.1, float(self.network_pps_policy.get("pps_window_sec", 5.0)))
+
+        for app_id, info in self.app_filter_info.items():
+            mark = info.get("mark")
+            if not mark:
+                continue
+            mark_value = int(mark, 16) if isinstance(mark, str) else int(mark)
+            packets = counts_by_mark.get(mark_value)
+            if packets is None:
+                continue
+            previous = self.app_pps_samples.get(app_id)
+            if previous:
+                previous_packets, previous_time = previous
+                elapsed = max(0.001, now - previous_time)
+                if elapsed <= max_window * 2:
+                    pps_rates[app_id] = max(0.0, packets - previous_packets) / elapsed
+            self.app_pps_samples[app_id] = (packets, now)
+
+        active_ids = set(self.app_filter_info.keys())
+        self.app_pps_samples = {
+            app_id: sample for app_id, sample in self.app_pps_samples.items()
+            if app_id in active_ids
+        }
+        self.app_pps_rates.update(pps_rates)
+        return pps_rates
+
+    def _evaluate_tx_pps_gate(self, network_data):
+        # Harm is either the egress byte-path (tx_fifo) or the softirq commons (softnet): a
+        # small-packet flood burns softirq without producing tx_fifo drops, so both count.
+        tx_harm = float(network_data.get("tx_collective_harm", 0.0) or 0.0)
+        softirq_harm = float(network_data.get("softirq_harm", 0.0) or 0.0)
+        harm = max(tx_harm, softirq_harm)
+        threshold = float(self.network_pps_policy.get("collective_harm_threshold", 0.5))
+        if harm < threshold:
+            return []
+
+        pps_rates = self._sample_app_pps()
+        pps_high = float(self.network_pps_policy.get("app_pps_high", 50000.0))
+        ranked_apps = {
+            app_id: self._tier_rank(info.get("priority", "low"))
+            for app_id, info in self.app_filter_info.items()
+            if info.get("mark")
+        }
+        if not ranked_apps:
+            if self._last_pps_gate_signature != "no_marked_apps":
+                logger.info("TX pps gate: collective harm %.3f but no marked apps are available", harm)
+                self._last_pps_gate_signature = "no_marked_apps"
+            return []
+
+        top_rank = max(ranked_apps.values())
+        candidates = []
+        for app_id, pps in pps_rates.items():
+            app_rank = ranked_apps.get(app_id, 1)
+            if pps >= pps_high and app_rank < top_rank:
+                candidates.append({
+                    "app_id": app_id,
+                    "pps": pps,
+                    "priority": self.app_filter_info[app_id].get("priority", "low"),
+                })
+
+        # Log on transitions only: a sustained flood keeps the same candidate set every
+        # eval cycle, and re-logging it each time is noise.
+        signature = ("hit", tuple(sorted(c["app_id"] for c in candidates))) if candidates else "miss"
+        if signature != self._last_pps_gate_signature:
+            if candidates:
+                logger.info(
+                    "TX pps gate: harm=%.3f (tx_fifo=%.3f softirq=%.3f) threshold=%.3f candidates=%s",
+                    harm,
+                    tx_harm,
+                    softirq_harm,
+                    threshold,
+                    ", ".join(f"{c['app_id']}:{c['priority']}:{c['pps']:.0f}pps" for c in candidates),
+                )
+            else:
+                logger.info(
+                    "TX pps gate: harm=%.3f (tx_fifo=%.3f softirq=%.3f) but no lower-priority app exceeded %.0fpps",
+                    harm,
+                    tx_harm,
+                    softirq_harm,
+                    pps_high,
+                )
+            self._last_pps_gate_signature = signature
+        return candidates
+
+    def _kernel_supports_pkt_police(self):
+        if self._app_pps_police_supported is not None:
+            return self._app_pps_police_supported
+        try:
+            result = subprocess.run(["uname", "-r"], capture_output=True, text=True, check=False)
+            version = getattr(result, "stdout", "").split("-", 1)[0]
+            major_minor = version.split(".")[:2]
+            major, minor = int(major_minor[0]), int(major_minor[1])
+            supported = (major, minor) >= (5, 17)
+        except (IndexError, TypeError, ValueError):
+            supported = False
+        self._app_pps_police_supported = supported
+        if not supported:
+            logger.warning("Per-app pps police requested but kernel support could not be confirmed")
+        return supported
+
+    def _apply_app_pps_cap(self, shaper, app_id):
+        if not self.enable_app_pps_police:
+            return False
+        if not self._kernel_supports_pkt_police():
+            return False
+
+        info = self.app_filter_info.get(app_id)
+        if not info or not info.get("mark"):
+            return False
+        dev_caps = self.app_pps_caps.setdefault(app_id, {})
+        if shaper.dev in dev_caps:
+            return True
+
+        prio = 3000 + len(self.app_pps_caps) * 10 + len(dev_caps)
+        mark_int = str(int(info["mark"], 16))
+        classid = info.get("nics", {}).get(shaper.dev, {}).get("classid_egress")
+        if not classid:
+            return False
+        subprocess.run(
+            [
+                "tc", "filter", "add", "dev", shaper.dev, "parent", f"{shaper.handle_id}:",
+                "protocol", "ip", "prio", str(prio), "u32", "match", "mark", mark_int,
+                "0xffffffff", "flowid", classid, "action", "police",
+                "pkts_rate", str(int(self.network_pps_policy.get("pps_cap_rate", 10000))),
+                "pkts_burst", str(int(self.network_pps_policy.get("pps_cap_burst", 2000))),
+                "conform-exceed", "drop",
+            ],
+            check=False,
+        )
+        dev_caps[shaper.dev] = {"prio": prio, "handle_id": shaper.handle_id}
+        logger.info("Applied TX pps cap to app %s on %s", app_id, shaper.dev)
+        return True
+
+    def _clear_app_pps_cap(self, app_id=None):
+        app_ids = [app_id] if app_id else list(self.app_pps_caps.keys())
+        for capped_app_id in app_ids:
+            for dev, cap in list(self.app_pps_caps.get(capped_app_id, {}).items()):
+                subprocess.run(
+                    [
+                        "tc", "filter", "del", "dev", dev, "parent", f"{cap['handle_id']}:",
+                        "protocol", "ip", "prio", str(cap["prio"]),
+                    ],
+                    check=False,
+                )
+                logger.info("Cleared TX pps cap for app %s on %s", capped_app_id, dev)
+            self.app_pps_caps.pop(capped_app_id, None)
+
+    def _cpu_mask(self):
+        # rps_cpus is a CPU bitmask. For >32 CPUs the kernel expects comma-separated
+        # 32-bit words, most-significant first (e.g. "000000ff,ffffffff"); for <=32 it
+        # accepts a single compact hex value (e.g. 4 CPUs -> "f").
+        cpus = max(1, os.cpu_count() or 1)
+        mask = (1 << cpus) - 1
+        if cpus <= 32:
+            return format(mask, "x")
+        words = []
+        while mask > 0:
+            words.append(format(mask & 0xffffffff, "08x"))
+            mask >>= 32
+        return ",".join(reversed(words))
+
+    def _escalate_rx(self, shaper):
+        state = self._rx_escalation_state.setdefault(shaper.dev, {"rps": {}, "sysctl": {}, "active": False})
+        # Apply once per activation: while the flood persists this is called every eval
+        # cycle, but re-writing the same RPS mask / re-logging each time is just noise.
+        if state.get("active"):
+            return
+        if self.network_pps_policy.get("enable_rps_escalation", True):
+            mask = self._cpu_mask()
+            for path in glob.glob(f"/sys/class/net/{shaper.dev}/queues/rx-*/rps_cpus"):
+                if path not in state["rps"]:
+                    try:
+                        with open(path, "r", encoding="utf-8") as f:
+                            state["rps"][path] = f.read().strip()
+                    except OSError:
+                        state["rps"][path] = "0"
+                try:
+                    with open(path, "w", encoding="utf-8") as f:
+                        f.write(mask)
+                except OSError as e:
+                    logger.warning("Failed to set RPS mask for %s: %s", path, str(e))
+
+        if self.network_pps_policy.get("enable_netdev_budget_bump", False):
+            for path, value in (
+                ("/proc/sys/net/core/netdev_max_backlog", "50000"),
+                ("/proc/sys/net/core/netdev_budget", "600"),
+            ):
+                if path not in state["sysctl"]:
+                    try:
+                        with open(path, "r", encoding="utf-8") as f:
+                            state["sysctl"][path] = f.read().strip()
+                    except OSError:
+                        continue
+                try:
+                    with open(path, "w", encoding="utf-8") as f:
+                        f.write(value)
+                except OSError as e:
+                    logger.warning("Failed to bump %s: %s", path, str(e))
+
+        state["active"] = True
+        logger.info("RX escalation active for %s", shaper.dev)
+
+    def _restore_rx(self, shaper):
+        state = self._rx_escalation_state.pop(shaper.dev, None)
+        if not state:
+            return
+        for path, value in state.get("rps", {}).items():
+            try:
+                with open(path, "w", encoding="utf-8") as f:
+                    f.write(value)
+            except OSError as e:
+                logger.warning("Failed to restore RPS mask for %s: %s", path, str(e))
+        for path, value in state.get("sysctl", {}).items():
+            try:
+                with open(path, "w", encoding="utf-8") as f:
+                    f.write(value)
+            except OSError as e:
+                logger.warning("Failed to restore %s: %s", path, str(e))
+        logger.info("RX escalation restored for %s", shaper.dev)
+
     def handle_network_pressure(self, shaper, tx_pressure, rx_pressure, ingress_rates, egress_rates, network_data):
         config_total_rate = shaper.total_bw
         tx_total_bw = shaper.total_bw * network_data['tx']
         rx_total_bw = shaper.total_bw * network_data['rx']
+        tx_collective_harm = float(network_data.get("tx_collective_harm", 0.0) or 0.0)
+        rx_collective_harm = float(network_data.get("rx_collective_harm", 0.0) or 0.0)
+        softirq_harm = float(network_data.get("softirq_harm", 0.0) or 0.0)
+        harm_threshold = float(self.network_pps_policy.get("collective_harm_threshold", 0.5))
+        # The per-app pps remedy (egress police, never byte shaping) fires on either TX
+        # byte-path harm (tx_pressure critical AND tx_fifo harm) or softirq-commons harm (a
+        # small-packet flood burning the receive softirq without lifting tx_pressure). The
+        # offender is always gated by priority in _evaluate_tx_pps_gate, so only a
+        # lower-priority flooder is ever capped.
+        tx_pps_gate_active = (
+            (tx_pressure == "critical" and tx_collective_harm >= harm_threshold)
+            or softirq_harm >= harm_threshold
+        )
         # TX throttle
-        if tx_pressure == "critical" and self._can_switch(self.limit_cooldown, shaper.tx_last_limit_time, shaper.tx_last_recover_time):
+        if tx_pps_gate_active:
+            candidates = self._evaluate_tx_pps_gate(network_data)
+            applied = False
+            for candidate in candidates:
+                if self._apply_app_pps_cap(shaper, candidate["app_id"]):
+                    applied = True
+            # Only advance the cooldown clock when a cap was actually installed; with police
+            # disabled (default) this branch is alert-only and must not gate later restore.
+            if applied:
+                shaper.tx_last_limit_time = time.time()
+        elif tx_pressure == "critical" and self._can_switch(self.limit_cooldown, shaper.tx_last_limit_time, shaper.tx_last_recover_time):
             self._apply_bandwidth_limit(shaper, shaper.tx_limit_stage, "egress", egress_rates, "tx_limit_stage")
             shaper.tx_last_limit_time = time.time()
+        elif tx_pressure != "critical":
+            self._clear_app_pps_cap()
         # RX throttle
-        if rx_pressure == "critical" and self._can_switch(self.limit_cooldown, shaper.rx_last_limit_time, shaper.rx_last_recover_time):
+        if rx_pressure == "critical" and rx_collective_harm >= harm_threshold:
+            self._escalate_rx(shaper)
+            shaper.rx_last_limit_time = time.time()
+        elif rx_pressure == "critical" and self._can_switch(self.limit_cooldown, shaper.rx_last_limit_time, shaper.rx_last_recover_time):
             self._apply_bandwidth_limit(shaper, shaper.rx_limit_stage, "ingress", ingress_rates, "rx_limit_stage")
             shaper.rx_last_limit_time = time.time()
+        elif (rx_pressure != "critical" and shaper.dev in self._rx_escalation_state
+              and self._can_switch(self.recover_cooldown, shaper.rx_last_limit_time, shaper.rx_last_recover_time)):
+            # Restore RX escalation only after a cooldown, so a score hovering at the critical
+            # edge does not flap the RPS masks on/off every eval cycle.
+            self._restore_rx(shaper)
+            shaper.rx_last_recover_time = time.time()
         # TX pressure restore
         if tx_pressure != "critical" and shaper.tx_limit_stage > 0 and self._can_switch(self.recover_cooldown, shaper.tx_last_limit_time, shaper.tx_last_recover_time):
             self._recover_network_pressure(
@@ -685,11 +1114,24 @@ class NetworkController:
         sampling and stats collection happen every iteration.
         """
         # Apply a pending hot reload first, on this (monitor) thread, before any
-        # per-cycle tc work. Checked even when shapers is empty so a controller
+        # per-cycle tc work. Checked even when monitors is empty so a controller
         # that started with no usable NIC can recover once config is fixed.
         if self._reload_pending.is_set():
             self._reload_pending.clear()
             self.reload()
+
+        # --- monitoring pass (independent of control): sample every usable NIC and
+        # publish the snapshot the dashboard reads. Runs even with no shapers, so the
+        # UI always shows live pressure rather than "NO DATA".
+        pressure_snapshot = {}
+        for dev, monitor in self.monitors.items():
+            try:
+                monitor.sample_network_pressure()
+                pressure_snapshot[dev] = monitor.get_current_pressure()
+            except Exception as e:
+                logger.error("Network pressure sampling failed for interface '%s': %s",
+                             dev, str(e), exc_info=True)
+        publish_network_pressure_snapshot(pressure_snapshot)
 
         if not self.shapers:
             return
@@ -697,8 +1139,8 @@ class NetworkController:
         if self.enable_network_control:
             self.update_app_network_control()
 
-        # Isolate failures per NIC: a tc/parsing error on one interface must not
-        # skip the remaining interfaces' sampling and shaping for this cycle.
+        # --- shaping pass: only shapeable NICs. Isolate failures per NIC so a
+        # tc/parsing error on one interface doesn't skip the rest this cycle.
         for shaper in self.shapers:
             try:
                 self._process_shaper_cycle(shaper, control_manager, do_pressure_eval)
@@ -714,18 +1156,22 @@ class NetworkController:
             shaper.monitor.get_tc_class_stats(shaper.dev, shaper.handle_id,
                                               classids=shaper.egress_classids,
                                               direction="egress")
-        shaper.monitor.sample_network_pressure()
+        # The monitor was already sampled this cycle by the monitoring pass; read the
+        # current fused score without re-sampling (a second sample this tick would halve
+        # the EMA/window dt and skew the score).
+        network_data = shaper.monitor.get_current_pressure()
 
         if not do_pressure_eval:
-            return
+            return network_data
 
-        network_data = shaper.monitor.get_current_pressure()
         tx_pressure, rx_pressure, *_ = control_manager.update_network_pressure_level(network_data)
         tx_total_bw = shaper.total_bw * network_data['tx']
         rx_total_bw = shaper.total_bw * network_data['rx']
         logger.debug(
             f"NetworkMonitor {shaper.dev} TX level: {tx_pressure} (pressure: {network_data['tx']:.2f}),"
             f" RX level: {rx_pressure} (pressure: {network_data['rx']:.2f})")
+        if not (self.enable_network_control and self.enable_network_pressure_shaping):
+            return network_data
         if self.enable_network_control and self.enable_network_pressure_shaping:
             ingress_rates = shaper.monitor.get_tc_class_stats_rate_ingress()
             egress_rates = shaper.monitor.get_tc_class_stats_rate_egress()
@@ -736,6 +1182,7 @@ class NetworkController:
                 f" RX_total_BW={rx_total_bw:,.2f}kbit/s (App Class BW: System - {rates['ingress_system']:,.2f},"
                 f" Critical - {rates['ingress_critical']:,.2f} , High - {rates['ingress_high']:,.2f}, Low - {rates['ingress_low']:,.2f})")
             self.handle_network_pressure(shaper, tx_pressure, rx_pressure, ingress_rates, egress_rates, network_data)
+            return network_data
 
     def _teardown_all(self):
         """Remove every tc qdisc, IFB device, and iptables mark rule we created.

--- a/config/config.py
+++ b/config/config.py
@@ -54,6 +54,15 @@ class Config:
     # monitor_idle_check_interval so detection latency stays short.
     limit_reap_interval: float = 2
     network_thresholds: dict = None
+    # Calibration knobs for the NIC pressure model (NetworkMonitor._model): EMA smoothing,
+    # distress decay, per-core pps budget, and drop/fifo/softnet half-points. Optional and
+    # partially overridable -- anything absent uses the module default in monitor/network.py.
+    network_pressure_model: dict = None
+    # Small-packet flood policy used by the network controller. Optional; controller
+    # fills missing keys with conservative defaults.
+    network_pps_policy: dict = None
+    # Optional TC-only per-application packet flood protection.
+    enable_app_pps_police: bool = False
     network_interfaces: list = None
     enable_network_control: bool = False
     enable_network_pressure_shaping: bool = True
@@ -763,6 +772,8 @@ class Config:
         Supported updates:
           * enable_network_control: bool
           * enable_network_pressure_shaping: bool
+          * enable_app_pps_police: bool
+          * network_pps_policy: {app_pps_high, pps_cap_rate, pps_cap_burst}
           * config_network_bw: {priority: {min: ratio, max: ratio}}
 
         Ratios are expected in [0, 1]. Only changed leaves are patched in YAML.
@@ -789,6 +800,26 @@ class Config:
                     self.enable_network_pressure_shaping = shaping_enabled
                     yaml_updates[("enable_network_pressure_shaping",)] = shaping_enabled
                     modified = True
+
+            if "enable_app_pps_police" in updates:
+                enabled = bool(updates["enable_app_pps_police"])
+                if getattr(self, "enable_app_pps_police", False) != enabled:
+                    self.enable_app_pps_police = enabled
+                    yaml_updates[("enable_app_pps_police",)] = enabled
+                    modified = True
+
+            pps_updates = updates.get("network_pps_policy")
+            if isinstance(pps_updates, dict):
+                current_policy = self.network_pps_policy if isinstance(self.network_pps_policy, dict) else {}
+                for key in ("app_pps_high", "pps_cap_rate", "pps_cap_burst"):
+                    if key not in pps_updates:
+                        continue
+                    value = int(pps_updates[key])
+                    if current_policy.get(key) != value:
+                        current_policy[key] = value
+                        yaml_updates[("network_pps_policy", key)] = value
+                        modified = True
+                self.network_pps_policy = current_policy
 
             bw_updates = updates.get("config_network_bw")
             if isinstance(bw_updates, dict):

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -262,13 +262,27 @@ limit_policy: # Default resource limit ratios for apps at different priority lev
       unknown:           # same as nvme
         mb_s: 30
         iops: 2000
-enable_network_control: false # Whether to enable network traffic control
-enable_network_pressure_shaping: false  # Whether to enable pressure-driven dynamic throttle/recover within network classes
+# Network control switches. All are disabled by default.
+enable_network_control: false  #Create and apply TC traffic classes to selected NICs.
+enable_network_pressure_shaping: false  #Adjust TC bandwidth limits when fused network pressure changes.
+enable_app_pps_police: false  #During a TX small-packet flood, cap lower-priority apps by packet rate.
+# Small-packet flood policy. An app exceeding app_pps_high is capped at
+# pps_cap_rate with the specified short burst when collective harm is detected.
+network_pps_policy:
+  app_pps_high: 50000    # PPS threshold for a lower-priority flood candidate
+  pps_cap_rate: 10000    # Sustained PPS cap applied to a selected app
+  pps_cap_burst: 2000    # Packets allowed above the sustained cap in a short burst
 network_thresholds:
   low: 0.3
   medium: 0.5
   high: 0.7
   critical: 0.9
+# NIC pressure calibration. Generic rx_dropped is driver/stack-specific, so it
+# contributes only half-strength. Hardware receive overflow and softnet backlog drops
+# remain full-strength capacity signals.
+# Values are re-read by the monitor each sample; valid range is 0.0 to 1.0.
+network_pressure_model:
+  rx_drop_weight: 0.3
 config_network_bw:  # ratio [0, 1] of NIC link bandwidth per network class
   system:
     min: 0.05
@@ -281,7 +295,7 @@ config_network_bw:  # ratio [0, 1] of NIC link bandwidth per network class
     max: 0.80
   low:
     min: 0.10
-    max: 0.80
+    max: 1.00
 network_burst_map:
   critical: "64k"
   high: "32k"

--- a/dashboard/src/api/types.ts
+++ b/dashboard/src/api/types.ts
@@ -42,7 +42,33 @@ export interface PressureData {
   network_total_nics?: number
   network_busy_ratio?: number | null
   network_busy_pct?: number | null
-  network_busy_level?: string
+  network_pressure_level?: string
+  network_pressure_pct?: number | null
+  network_worst_nic?: string | null
+  network_worst_direction?: string | null
+  // Per-NIC, per-direction pressure diagnostics (why a direction is under pressure).
+  network_interfaces?: Record<string, NetworkInterfacePressure>
+}
+
+// One direction's (rx or tx) pressure breakdown, all percent-scaled. Fields specific to
+// a direction (hw_overflow/softnet on rx, fifo on tx) are optional so the other omits them.
+export interface NetworkDirectionPressure {
+  util_pct?: number
+  distress_pct?: number
+  score_pct?: number
+  drop_ratio_pct?: number
+  hw_overflow_ratio_pct?: number
+  softnet_squeeze_ratio_pct?: number
+  softnet_drop_ratio_pct?: number
+  fifo_ratio_pct?: number
+  collective_harm_pct?: number
+  level?: string
+  reason?: string | null
+}
+
+export interface NetworkInterfacePressure {
+  rx?: NetworkDirectionPressure
+  tx?: NetworkDirectionPressure
 }
 
 export interface AppInfo {

--- a/dashboard/src/components/HistoryDashboard.tsx
+++ b/dashboard/src/components/HistoryDashboard.tsx
@@ -556,9 +556,9 @@ function buildPressureTrendPoints(items: HistorySnapshotItem[]): PressureTrendPo
     // Disk pressure: busy-disk ratio from _compute_disk_pressure (busy_disks/total_disks × 100)
     const diskBusyPct = (dynamic?.disk as Record<string, unknown> | undefined)?.busy_pct
     const diskPressure = isNumber(diskBusyPct as number | null) ? (diskBusyPct as number) : null
-    // Network pressure: busy-NIC ratio from _compute_network_pressure (busy_nics/total_nics × 100)
-    const netBusyPct = (dynamic?.pressure as Record<string, unknown> | undefined)?.network_busy_pct
-    const networkPressure = isNumber(netBusyPct as number | null) ? (netBusyPct as number) : null
+    // Network pressure: worst fused RX/TX score across monitored NICs.
+    const netPressurePct = (dynamic?.pressure as Record<string, unknown> | undefined)?.network_pressure_pct
+    const networkPressure = isNumber(netPressurePct as number | null) ? (netPressurePct as number) : null
     return {
       timestamp: label,
       ts,
@@ -703,23 +703,48 @@ function buildNetworkTrendPoints(items: HistorySnapshotItem[]): { points: Networ
 
     const network = dynamic?.network as (DynamicInfoData['network'] & {
       per_nic?: Record<string, { util?: number | null; rx_mbps?: number | null; tx_mbps?: number | null; rx?: number | null; tx?: number | null; speed_mbps?: number | null } | number | null>
+      interfaces?: Record<string, { rx_bytes_per_sec?: number | null; tx_bytes_per_sec?: number | null }>
+      pressure_interfaces?: DynamicInfoData['pressure']['network_interfaces']
     }) | undefined
-    const perNic = network?.per_nic
+    const pressureInterfaces = dynamic?.pressure?.network_interfaces ?? network?.pressure_interfaces
+    const perNic = network?.per_nic ?? (network?.interfaces
+      ? Object.fromEntries(Object.entries(network.interfaces).map(([name, value]) => [name, {
+          rx_mbps: toNumber(value?.rx_bytes_per_sec) != null ? (value.rx_bytes_per_sec as number) / 1_000_000 : null,
+          tx_mbps: toNumber(value?.tx_bytes_per_sec) != null ? (value.tx_bytes_per_sec as number) / 1_000_000 : null,
+        }]))
+      : undefined)
     if (perNic && typeof perNic === 'object') {
       for (const [name, val] of Object.entries(perNic)) {
         nicNameSet.add(name)
         if (val && typeof val === 'object') {
-          const rxTxMax = val.rx != null || val.tx != null ? Math.max(val.rx ?? 0, val.tx ?? 0) : null
-          point[`${name}:util`] = toNumber(val.util) ?? normalizePressureFraction(rxTxMax)
+          const speed = toNumber(val.speed_mbps)
+          const rxMbps = toNumber(val.rx_mbps)
+          const txMbps = toNumber(val.tx_mbps)
+          point[`${name}:rxUtil`] = speed && speed > 0 && rxMbps != null
+            ? Math.min(rxMbps / speed * 100, 100)
+            : null
+          point[`${name}:txUtil`] = speed && speed > 0 && txMbps != null
+            ? Math.min(txMbps / speed * 100, 100)
+            : null
           point[`${name}:rx`] = toNumber(val.rx_mbps) ?? null
           point[`${name}:tx`] = toNumber(val.tx_mbps) ?? null
+          const pressure = pressureInterfaces?.[name]
+          point[`${name}:rxLoss`] = toNumber(pressure?.rx?.drop_ratio_pct)
+          point[`${name}:rxCongestion`] = toNumber(pressure?.rx?.distress_pct)
+          point[`${name}:txLoss`] = toNumber(pressure?.tx?.drop_ratio_pct)
+          point[`${name}:txCongestion`] = toNumber(pressure?.tx?.distress_pct)
           const sp = toNumber(val.speed_mbps)
           if (sp != null && sp > 0) speedMap[name] = sp
         } else {
           // Old format: single utilization number
-          point[`${name}:util`] = typeof val === 'number' ? normalizePercent(val) : null
+          point[`${name}:rxUtil`] = null
+          point[`${name}:txUtil`] = null
           point[`${name}:rx`] = null
           point[`${name}:tx`] = null
+          point[`${name}:rxLoss`] = null
+          point[`${name}:rxCongestion`] = null
+          point[`${name}:txLoss`] = null
+          point[`${name}:txCongestion`] = null
         }
       }
     } else {
@@ -727,9 +752,15 @@ function buildNetworkTrendPoints(items: HistorySnapshotItem[]): { points: Networ
       const aggUtil = toNumber((network as DynamicInfoData['network'] & HistoryNetworkExtra)?.utilization_percent)
       if (aggUtil != null) {
         nicNameSet.add('total')
-        point['total:util'] = aggUtil
+        // The legacy aggregate has no direction split; do not present it as RX.
+        point['total:rxUtil'] = null
+        point['total:txUtil'] = null
         point['total:rx'] = null
         point['total:tx'] = null
+        point['total:rxLoss'] = null
+        point['total:rxCongestion'] = null
+        point['total:txLoss'] = null
+        point['total:txCongestion'] = null
       }
     }
     return point
@@ -2623,9 +2654,14 @@ export default function HistoryDashboard({ active }: Props) {
       {/* Network — Utilization & Bandwidth per NIC */}
       {visibleSections.includes('network') && !loading && nicNames.length > 0 && nicNames.map((nicName) => {
         const nicLines: Array<{ key: string; name: string; color: string; dasharray?: string; yAxisId: string }> = [
-          { key: `${nicName}:util`, name: 'Util %', color: METRIC_COLORS.util, yAxisId: 'util' },
-          { key: `${nicName}:rx`, name: 'RX Mbps', color: METRIC_COLORS.rx, yAxisId: 'bw' },
-          { key: `${nicName}:tx`, name: 'TX Mbps', color: METRIC_COLORS.tx, yAxisId: 'bw' },
+          { key: `${nicName}:rxUtil`, name: 'Receive (RX) Util %', color: METRIC_COLORS.rx, yAxisId: 'util' },
+          { key: `${nicName}:txUtil`, name: 'Send (TX) Util %', color: METRIC_COLORS.tx, yAxisId: 'util' },
+          { key: `${nicName}:rx`, name: 'Receive (RX) Mbps', color: METRIC_COLORS.rx, yAxisId: 'bw' },
+          { key: `${nicName}:tx`, name: 'Send (TX) Mbps', color: METRIC_COLORS.tx, yAxisId: 'bw' },
+          { key: `${nicName}:rxLoss`, name: 'Receive (RX) Packet Loss %', color: '#f59e0b', dasharray: '5 3', yAxisId: 'util' },
+          { key: `${nicName}:rxCongestion`, name: 'Receive (RX) Congestion %', color: '#fb7185', dasharray: '2 2', yAxisId: 'util' },
+          { key: `${nicName}:txLoss`, name: 'Send (TX) Packet Loss %', color: '#a78bfa', dasharray: '5 3', yAxisId: 'util' },
+          { key: `${nicName}:txCongestion`, name: 'Send (TX) Congestion %', color: '#f97316', dasharray: '2 2', yAxisId: 'util' },
         ]
         return (
         <Card

--- a/dashboard/src/components/SettingsModal.tsx
+++ b/dashboard/src/components/SettingsModal.tsx
@@ -781,20 +781,36 @@ function NetworkPressurePanel() {
         description="Bands for the network channel: the utilisation of the monitored interfaces is graded against these thresholds, and the level drives the pressure-based bandwidth shaping in Network Control."
         scope="network_pressure"
         load={async () => {
-          const d = await api.getConfig<{ network_thresholds: Record<string, number>; updated_at?: number }>('network_pressure')
-          return { values: { network_thresholds: toPercentageThresholds(d.network_thresholds) }, updatedAt: d.updated_at }
+          const d = await api.getConfig<{
+            network_thresholds: Record<string, number>
+            network_pressure_model?: { rx_drop_weight?: number }
+            updated_at?: number
+          }>('network_pressure')
+          return {
+            values: {
+              network_thresholds: toPercentageThresholds(d.network_thresholds),
+              network_pressure_model_rx_drop_weight: Number(d.network_pressure_model?.rx_drop_weight ?? 0.5),
+            },
+            updatedAt: d.updated_at,
+          }
         }}
         save={(values, ts) => api.updateConfig('network_pressure', {
           network_thresholds: toRatioThresholds(values.network_thresholds as Record<string, number>),
+          network_pressure_model: {
+            rx_drop_weight: Number(values.network_pressure_model_rx_drop_weight),
+          },
         }, ts)}
         currentToValues={(c) => ({
           network_thresholds: toPercentageThresholds(c.network_thresholds as Record<string, number>),
+          network_pressure_model_rx_drop_weight: Number(
+            ((c.network_pressure_model as { rx_drop_weight?: number } | undefined)?.rx_drop_weight) ?? 0.5,
+          ),
         })}
       >
         <Divider orientation="left" orientationMargin={0} plain style={{ margin: '4px 0 12px' }}>
           <SectionLabel
-            text="Utilisation thresholds (%, ordered)"
-            tip="Maps overall network utilisation to low, medium, high, and critical. Thresholds must increase in that order."
+            text="Network pressure thresholds (%, ordered)"
+            tip="Maps the fused network pressure score to low, medium, high, and critical. The score combines near-saturation utilisation with congestion distress such as drops, FIFO overflow, and softnet pressure. Thresholds must increase in that order."
           />
         </Divider>
         <Row gutter={16}>
@@ -811,6 +827,22 @@ function NetworkPressurePanel() {
             </Col>
           ))}
         </Row>
+
+        <AdvancedSection>
+          <Row gutter={16}>
+            <Col span={8}>
+              <Form.Item
+                label="RX drop weight"
+                name="network_pressure_model_rx_drop_weight"
+                tooltip="Weight of generic rx_dropped distress in RX pressure scoring. Lower values make RX drops contribute less to pressure; valid range is 0 to 1."
+                required={false}
+                rules={[{ required: true, type: 'number', min: 0, max: 1 }]}
+              >
+                <InputNumber style={{ width: '100%' }} min={0} max={1} step={0.05} />
+              </Form.Item>
+            </Col>
+          </Row>
+        </AdvancedSection>
       </FormCard>
     </>
   )
@@ -1260,6 +1292,8 @@ function NetworkPanel() {
         const d = await api.getConfig<{
           enable_network_control: boolean
           enable_network_pressure_shaping: boolean
+          enable_app_pps_police: boolean
+          network_pps_policy: { app_pps_high: number; pps_cap_rate: number; pps_cap_burst: number }
           available_network_interfaces: Array<{ name: string; speed_mbps: number }>
           selected_network_interfaces: string[]
           config_network_bw: Record<string, { min: number; max: number }>
@@ -1271,6 +1305,8 @@ function NetworkPanel() {
           values: {
             enable_network_control: Boolean(d.enable_network_control),
             enable_network_pressure_shaping: Boolean(d.enable_network_pressure_shaping ?? true),
+            enable_app_pps_police: Boolean(d.enable_app_pps_police),
+            network_pps_policy: d.network_pps_policy,
             available_network_interfaces: d.available_network_interfaces ?? [],
             selected_network_interfaces: d.selected_network_interfaces ?? [],
             config_network_bw: toPercentages(d.config_network_bw),
@@ -1283,6 +1319,8 @@ function NetworkPanel() {
         api.updateConfig('network_control', {
           enable_network_control: Boolean(values.enable_network_control),
           enable_network_pressure_shaping: Boolean(values.enable_network_pressure_shaping),
+          enable_app_pps_police: Boolean(values.enable_app_pps_police),
+          network_pps_policy: values.network_pps_policy,
           ...(Boolean(values.enable_network_control)
             ? { selected_network_interfaces: values.selected_network_interfaces }
             : {}),
@@ -1299,6 +1337,8 @@ function NetworkPanel() {
       currentToValues={(c) => ({
         enable_network_control: Boolean(c.enable_network_control),
         enable_network_pressure_shaping: Boolean(c.enable_network_pressure_shaping ?? true),
+        enable_app_pps_police: Boolean(c.enable_app_pps_police),
+        network_pps_policy: c.network_pps_policy,
         available_network_interfaces: c.available_network_interfaces,
         selected_network_interfaces: c.selected_network_interfaces,
         config_network_bw: toPercentages(c.config_network_bw as Record<string, { min: number; max: number }> | undefined),
@@ -1308,6 +1348,8 @@ function NetworkPanel() {
       <Form.Item noStyle shouldUpdate>
         {({ getFieldValue, setFieldsValue }) => {
           const networkControlEnabled = Boolean(getFieldValue('enable_network_control'))
+          const pressureShapingEnabled = Boolean(getFieldValue('enable_network_pressure_shaping'))
+          const packetFloodProtectionEnabled = Boolean(getFieldValue('enable_app_pps_police'))
           const availableNetworkInterfaces = (
             getFieldValue('available_network_interfaces') as Array<{ name: string; speed_mbps: number }> | undefined
           ) ?? []
@@ -1386,7 +1428,72 @@ function NetworkPanel() {
                         />
                       </Form.Item>
                     </Col>
+                    <Col span={14}>
+                      <Form.Item
+                        label="Per-app packet flood protection"
+                        name="enable_app_pps_police"
+                        valuePropName="checked"
+                        tooltip="Caps lower-priority outbound applications only when fused TX pressure indicates a small-packet flood. Requires automatic network control."
+                      >
+                        <Switch
+                          checkedChildren="On"
+                          unCheckedChildren="Off"
+                          disabled={!networkControlEnabled || !pressureShapingEnabled}
+                        />
+                      </Form.Item>
+                    </Col>
                   </Row>
+
+                  <AdvancedSection>
+                    <Divider orientation="left" orientationMargin={0} plain style={{ margin: '0 0 12px' }}>
+                      <SectionLabel
+                        text="Packet flood policy"
+                        tip="Tune the outbound small-packet flood candidate threshold and the per-app packet-rate cap. Changes apply when packet flood protection is enabled."
+                      />
+                    </Divider>
+                    <Row gutter={12}>
+                      <Col span={8}>
+                        <Form.Item
+                          label="Candidate threshold (PPS)"
+                          name={['network_pps_policy', 'app_pps_high']}
+                          tooltip="A lower-priority app must exceed this outbound packet rate, while causing network harm, before packet flood protection can select it for limiting. Use it as the upper reference when setting the per-app cap."
+                          rules={[{ required: true, type: 'integer', min: 1 }]}
+                        >
+                          <InputNumber style={{ width: '100%' }} min={1} step={1000} disabled={!networkControlEnabled || !pressureShapingEnabled || !packetFloodProtectionEnabled} />
+                        </Form.Item>
+                      </Col>
+                      <Col span={8}>
+                        <Form.Item
+                          label="Per-app cap (PPS)"
+                          name={['network_pps_policy', 'pps_cap_rate']}
+                          tooltip="The sustained packet-rate limit applied after an app exceeds the candidate threshold and is selected for protection. Packets above this rate are dropped after its burst allowance is used."
+                          dependencies={[['network_pps_policy', 'app_pps_high']]}
+                          rules={[
+                            { required: true, type: 'integer', min: 1 },
+                            ({ getFieldValue }) => ({
+                              validator(_, value) {
+                                const threshold = getFieldValue(['network_pps_policy', 'app_pps_high'])
+                                return value <= threshold
+                                  ? Promise.resolve()
+                                  : Promise.reject(new Error('Cap cannot exceed candidate threshold'))
+                              },
+                            }),
+                          ]}
+                        >
+                          <InputNumber style={{ width: '100%' }} min={1} step={1000} disabled={!networkControlEnabled || !pressureShapingEnabled || !packetFloodProtectionEnabled} />
+                        </Form.Item>
+                      </Col>
+                      <Col span={8}>
+                        <Form.Item
+                          label="Burst (packets)"
+                          name={['network_pps_policy', 'pps_cap_burst']}
+                          rules={[{ required: true, type: 'integer', min: 1 }]}
+                        >
+                          <InputNumber style={{ width: '100%' }} min={1} step={100} disabled={!networkControlEnabled || !pressureShapingEnabled || !packetFloodProtectionEnabled} />
+                        </Form.Item>
+                      </Col>
+                    </Row>
+                  </AdvancedSection>
 
                   <Divider orientation="left" orientationMargin={0} plain style={{ margin: '4px 0 12px' }}>
                     <SectionLabel

--- a/dashboard/src/components/SystemOverview.tsx
+++ b/dashboard/src/components/SystemOverview.tsx
@@ -39,6 +39,7 @@ import type {
   GpuUsageDevice,
   GpuUsageFreq,
   DiskDeviceData,
+  NetworkInterfacePressure,
 } from '../api/types'
 import { usePolling } from '../hooks/usePolling'
 import { useDocumentVisible } from '../hooks/useDocumentVisible'
@@ -1520,6 +1521,45 @@ function DetailItem({
   )
 }
 
+/** Critical-reason banner for the Network card: only when a direction is CRITICAL. */
+function networkPressureAlert(
+  pressure: NetworkInterfacePressure | null | undefined,
+): { text: string; color: string } | undefined {
+  if (!pressure) return undefined
+  const parts: string[] = []
+  if ((pressure.rx?.level || '').toUpperCase() === 'CRITICAL') {
+    parts.push(`Receive (RX) critical: ${pressure.rx?.reason || 'congestion'}`)
+  }
+  if ((pressure.tx?.level || '').toUpperCase() === 'CRITICAL') {
+    parts.push(`Send (TX) critical: ${pressure.tx?.reason || 'congestion'}`)
+  }
+  if (!parts.length) return undefined
+  return { text: parts.join('   ·   '), color: COLORS.red }
+}
+
+type DetailRow = { label: string; value: string; source?: DataSourceKind; divider?: boolean }
+
+/** Per-direction Network-card metrics expose throughput, delivery loss, and buffer pressure. */
+function networkPressureDetails(
+  pressure: NetworkInterfacePressure | null | undefined,
+  rxRate: number | null,
+  txRate: number | null,
+): DetailRow[] {
+  const pct = (v?: number) => (isNumber(v) ? `${v.toFixed(2)}%` : '—')
+  const rx = pressure?.rx || {}
+  const tx = pressure?.tx || {}
+  return [
+    { label: 'Receive (RX)', value: '', divider: true },
+    { label: 'Bandwidth', value: formatMetric(toMbps(rxRate), 'Mb/s', 2), source: 'dynamic' },
+    { label: 'Packet Loss', value: pct(rx.drop_ratio_pct), source: 'dynamic' },
+    { label: 'Buffer Overflow', value: pct(rx.hw_overflow_ratio_pct), source: 'dynamic' },
+    { label: 'Send (TX)', value: '', divider: true },
+    { label: 'Bandwidth', value: formatMetric(toMbps(txRate), 'Mb/s', 2), source: 'dynamic' },
+    { label: 'Packet Loss', value: pct(tx.drop_ratio_pct), source: 'dynamic' },
+    { label: 'Buffer Overflow', value: pct(tx.fifo_ratio_pct), source: 'dynamic' },
+  ]
+}
+
 function TrendPanel({
   title,
   accent,
@@ -1546,6 +1586,7 @@ function TrendPanel({
   secondaryChartGap = 10,
   detailTopMargin = 12,
   primaryChartLabel,
+  alert,
 }: {
   title: string
   accent: string
@@ -1572,6 +1613,7 @@ function TrendPanel({
   secondaryChartGap?: number
   detailTopMargin?: number
   primaryChartLabel?: string
+  alert?: { text: string; color: string }
 }) {
   const gaugeValue = isNumber(value) ? Math.max(0, Math.min(value, 100)) : 0
   const hasValue = isNumber(value)
@@ -1604,6 +1646,23 @@ function TrendPanel({
           )}
         </Space>
       </div>
+      {alert && (
+        <div
+          style={{
+            marginTop: 8,
+            padding: '6px 10px',
+            borderRadius: 6,
+            border: `1px solid ${alert.color}`,
+            background: `${alert.color}1a`,
+            color: alert.color,
+            fontSize: 11,
+            fontWeight: 600,
+            lineHeight: 1.4,
+          }}
+        >
+          {alert.text}
+        </div>
+      )}
       <div className={`perf-trend-body ${hasSplitBars ? 'perf-trend-body--split' : ''} ${centerBody ? 'perf-trend-body--center' : ''}`}>
         <div className="perf-trend-main">
           <div className="perf-insight-metric">
@@ -2754,12 +2813,12 @@ export default function SystemOverview({ active }: Props) {
     const txBwKey = nicName ? `bw:network:${nicName}:tx_mbps` : 'bw:network:tx_mbps'
 
     const utilSeries = [
-      { key: `${nicName || 'net'}-rx-util`, label: 'RX Util %', data: getSeries(rxUtilKey), stroke: PERF_COLORS.network },
-      { key: `${nicName || 'net'}-tx-util`, label: 'TX Util %', data: getSeries(txUtilKey), stroke: PERF_COLORS.gpu },
+      { key: `${nicName || 'net'}-rx-util`, label: 'Receive (RX) Util %', data: getSeries(rxUtilKey), stroke: PERF_COLORS.network },
+      { key: `${nicName || 'net'}-tx-util`, label: 'Send (TX) Util %', data: getSeries(txUtilKey), stroke: PERF_COLORS.gpu },
     ]
     const bwSeries = [
-      { key: `${nicName || 'net'}-rx-bw-kbps`, label: 'RX BW Kb/s', data: getSeries(rxBwKey).map((v) => (isNumber(v) ? v * 1000 : null)), stroke: PERF_COLORS.network },
-      { key: `${nicName || 'net'}-tx-bw-kbps`, label: 'TX BW Kb/s', data: getSeries(txBwKey).map((v) => (isNumber(v) ? v * 1000 : null)), stroke: PERF_COLORS.gpu },
+      { key: `${nicName || 'net'}-rx-bw-kbps`, label: 'Receive (RX) BW Kb/s', data: getSeries(rxBwKey).map((v) => (isNumber(v) ? v * 1000 : null)), stroke: PERF_COLORS.network },
+      { key: `${nicName || 'net'}-tx-bw-kbps`, label: 'Send (TX) BW Kb/s', data: getSeries(txBwKey).map((v) => (isNumber(v) ? v * 1000 : null)), stroke: PERF_COLORS.gpu },
     ]
     const bwValues = [...bwSeries[0].data, ...bwSeries[1].data].filter(isNumber)
     const bwMax = bwValues.length ? Math.max(...bwValues) : 0
@@ -2930,7 +2989,8 @@ export default function SystemOverview({ active }: Props) {
       const txUtil = isNumber(txMbps) && isNumber(bandwidth) && bandwidth > 0 ? Math.min(txMbps / bandwidth * 100, 100) : null
       const utilValues = [rxUtil, txUtil].filter(isNumber)
       const utilMax = utilValues.length ? Math.max(...utilValues) : null
-      return { nicName, bandwidth, rxRate, txRate, rxUtil, txUtil, utilMax }
+      const pressure = dynamicInfo?.pressure?.network_interfaces?.[nicName] ?? null
+      return { nicName, bandwidth, rxRate, txRate, rxUtil, txUtil, utilMax, pressure }
     })
   }, [validNics, dynamicInfo])
 
@@ -3018,12 +3078,22 @@ export default function SystemOverview({ active }: Props) {
   // when severity is unavailable (USE-only path with no pressure tick).
   const diskPressurePct = dynamicInfo?.disk?.pressure_pct ?? diskBusyPct
 
-  // Network pressure: read pre-computed values from backend
+  // Network pressure is the worst fused RX/TX score across controlled NICs;
+  // busy-NIC count separately describes how broadly the pressure is spread.
   const networkBusyNics = dynamicInfo?.pressure?.network_busy_nics ?? []
   const networkTotalCount = dynamicInfo?.pressure?.network_total_nics ?? 0
   const networkBusyCount = networkBusyNics.length
-  const networkPressurePct = dynamicInfo?.pressure?.network_busy_pct ?? null
-  const networkBusyLevelLabel = dynamicInfo?.pressure?.network_busy_level ?? 'NO DATA'
+  const networkPressurePct = dynamicInfo?.pressure?.network_pressure_pct ?? null
+  const networkPressureLevelLabel = dynamicInfo?.pressure?.network_pressure_level ?? 'NO DATA'
+  const networkWorstNic = dynamicInfo?.pressure?.network_worst_nic ?? null
+  const networkWorstDirection = dynamicInfo?.pressure?.network_worst_direction ?? null
+  // Short "why" for the overview gauge when it turns critical, pulled from the worst NIC's
+  // worst direction so the summary card is self-explanatory without opening the NIC card.
+  const networkWorstReason = (() => {
+    if (!networkWorstNic || !networkWorstDirection) return null
+    const dir = networkWorstDirection.toLowerCase() === 'tx' ? 'tx' : 'rx'
+    return dynamicInfo?.pressure?.network_interfaces?.[networkWorstNic]?.[dir]?.reason ?? null
+  })()
 
   const npuSmiRaw = dynamicInfo?.npu?.npu_smi?.raw
   const npuParsed = useMemo(() => parseNpuRaw(npuSmiRaw), [npuSmiRaw])
@@ -3272,18 +3342,20 @@ export default function SystemOverview({ active }: Props) {
             </>
           )}
 
-          {/* Network IO Pressure: fraction of busy NICs based on actual link speed */}
+          {/* Network pressure: worst fused NIC/direction, with busy-NIC breadth below. */}
           {showNetworkPressureCard && (
             <Col xs={24} md={showPressureSection ? 8 : 12}>
               <PressurePointerGauge
-                title="Network IO Pressure"
+                title="Network Pressure"
                 valuePct={networkPressurePct}
-                levelLabel={networkBusyLevelLabel}
+                levelLabel={networkPressureLevelLabel}
                 subtitle={[
-                  networkBusyCount > 0 ? `Busy: ${networkBusyNics.join(', ')}` : null,
+                  networkPressureLevelLabel === 'CRITICAL' && networkWorstReason
+                    ? `${networkWorstNic || ''}${networkWorstDirection ? ` (${networkWorstDirection})` : ''}: ${networkWorstReason}`
+                    : (networkBusyCount > 0 && networkWorstNic ? `Busy: ${networkWorstNic}${networkWorstDirection ? ` (${networkWorstDirection})` : ''}` : null),
                   networkTotalCount > 0 ? `${networkBusyCount}/${networkTotalCount} NICs busy` : null,
                 ].filter(Boolean).join(' | ')}
-                description="Fraction of busy NICs based on actual link speed"
+                description="Worst fused RX/TX pressure; subtitle shows the reason when critical, else affected NICs"
               />
             </Col>
           )}
@@ -3410,14 +3482,14 @@ export default function SystemOverview({ active }: Props) {
                 statusColor={isNumber(nic.utilMax) && nic.utilMax >= 80 ? COLORS.red : PERF_COLORS.network}
                 series={getSeries(`util:network:${nic.nicName}`)}
                 splitBars={[
-                  { key: 'rx-bar', label: 'RX', value: nic.rxUtil, color: PERF_COLORS.network, sublabel: `${formatBytesRate(nic.rxRate)}` },
-                  { key: 'tx-bar', label: 'TX', value: nic.txUtil, color: PERF_COLORS.gpu, sublabel: `${formatBytesRate(nic.txRate)}` },
+                  { key: 'rx-bar', label: 'Receive (RX)', value: nic.rxUtil, color: PERF_COLORS.network, sublabel: `${formatBytesRate(nic.rxRate)}` },
+                  { key: 'tx-bar', label: 'Send (TX)', value: nic.txUtil, color: PERF_COLORS.gpu, sublabel: `${formatBytesRate(nic.txRate)}` },
                 ]}
                 subtitle={`Peak BW: ${formatNetworkSpeed(nic.bandwidth)}`}
+                alert={networkPressureAlert(nic.pressure)}
                 details={[
                   { label: 'Util', value: formatPercent(nic.utilMax), source: 'dynamic' },
-                  { label: 'RX BW', value: formatMetric(toMbps(nic.rxRate), 'Mb/s', 2), source: 'dynamic' },
-                  { label: 'TX BW', value: formatMetric(toMbps(nic.txRate), 'Mb/s', 2), source: 'dynamic' },
+                  ...networkPressureDetails(nic.pressure, nic.rxRate, nic.txRate),
                 ]}
                 secondaryChart={(
                   <div>
@@ -3470,8 +3542,8 @@ export default function SystemOverview({ active }: Props) {
               statusColor={isNumber(networkUtilMax) && networkUtilMax >= 80 ? COLORS.red : PERF_COLORS.network}
               series={getSeries(networkNicCards.length === 1 ? `util:network:${networkNicCards[0].nicName}` : 'util:network')}
               splitBars={[
-                { key: 'rx-bar', label: 'RX', value: networkNicCards.length === 1 ? networkNicCards[0].rxUtil : fallbackRxUtil, color: PERF_COLORS.network, sublabel: formatBytesRate(networkNicCards.length === 1 ? networkNicCards[0].rxRate : fallbackRxRate) },
-                { key: 'tx-bar', label: 'TX', value: networkNicCards.length === 1 ? networkNicCards[0].txUtil : fallbackTxUtil, color: PERF_COLORS.gpu, sublabel: formatBytesRate(networkNicCards.length === 1 ? networkNicCards[0].txRate : fallbackTxRate) },
+                { key: 'rx-bar', label: 'Receive (RX)', value: networkNicCards.length === 1 ? networkNicCards[0].rxUtil : fallbackRxUtil, color: PERF_COLORS.network, sublabel: formatBytesRate(networkNicCards.length === 1 ? networkNicCards[0].rxRate : fallbackRxRate) },
+                { key: 'tx-bar', label: 'Send (TX)', value: networkNicCards.length === 1 ? networkNicCards[0].txUtil : fallbackTxUtil, color: PERF_COLORS.gpu, sublabel: formatBytesRate(networkNicCards.length === 1 ? networkNicCards[0].txRate : fallbackTxRate) },
               ]}
               subtitle={networkNicCards.length === 1
                 ? `Peak BW: ${formatNetworkSpeed(networkNicCards[0].bandwidth)}`
@@ -3482,10 +3554,14 @@ export default function SystemOverview({ active }: Props) {
                     ].filter(Boolean).join(' | ')
                   : 'No data'
               }
+              alert={networkNicCards.length === 1 ? networkPressureAlert(networkNicCards[0].pressure) : undefined}
               details={[
                 { label: 'Util', value: formatPercent(networkNicCards.length === 1 ? networkNicCards[0].utilMax : fallbackUtilMax), source: 'dynamic' },
-                { label: 'RX BW', value: formatMetric(toMbps(networkNicCards.length === 1 ? networkNicCards[0].rxRate : fallbackRxRate), 'Mb/s', 2), source: 'dynamic' },
-                { label: 'TX BW', value: formatMetric(toMbps(networkNicCards.length === 1 ? networkNicCards[0].txRate : fallbackTxRate), 'Mb/s', 2), source: 'dynamic' },
+                ...networkPressureDetails(
+                  networkNicCards.length === 1 ? networkNicCards[0].pressure : null,
+                  networkNicCards.length === 1 ? networkNicCards[0].rxRate : fallbackRxRate,
+                  networkNicCards.length === 1 ? networkNicCards[0].txRate : fallbackTxRate,
+                ),
               ]}
               secondaryChart={(
                 <div>

--- a/docs/pressure_algorithm.md
+++ b/docs/pressure_algorithm.md
@@ -7,23 +7,28 @@ How SmarTune turns raw kernel signals into a **pressure score** and a
 **pressure level** (`low / medium / high / critical`) that drives auto-throttling
 and staged restore.
 
-There are **two independent channels**, each with its own score, bands and level state:
-the **system** channel, driven mostly by memory, and the **disk-IO** channel, which
-decides `io.max` throttling on its own. They share the input plumbing, the
-self-inflicted discount and the smoothing machinery — nothing else. That split is
+There are **three independent channels**, each with its own score, bands and level state:
+the **system** channel, driven mostly by memory; the **disk-IO** channel, which decides
+`io.max` throttling on its own; and the **network** channel, which decides per-direction
+bandwidth shaping. The system and disk channels share the input plumbing, the
+self-inflicted discount and the smoothing machinery; the network channel is more
+self-contained — it does its own signal-level smoothing (EMA + a distress capacitor) and
+maps straight to `network_thresholds`, without the §4 score→level filter. That split is
 what this document is organised around:
 
 | | |
 |---|---|
-| [**Part I — Shared machinery**](#part-i--shared-machinery) | the pipeline, the inputs, the self-inflicted discount, and the score → level filter that both channels run |
+| [**Part I — Shared machinery**](#part-i--shared-machinery) | the pipeline, the inputs, the self-inflicted discount, and the score → level filter that the system and disk channels run |
 | [**Part II — The system channel**](#part-ii--the-system-channel) | the memory sigmoid, the weighted average, and why memory alone can reach `critical` |
 | [**Part III — The disk-IO channel**](#part-iii--the-disk-io-channel) | the per-disk USE model, the noisy-OR, the PSI gate, and what a `critical` disk level does |
+| [**Part IV — The network channel**](#part-iv--the-network-channel) | the utilisation saturation gate, the drop/queue distress signal, and why a busy-but-clean link is not pressure |
 | [**Appendix — Parameter reference**](#appendix--parameter-reference) | every knob, which direction moves it, and a tuning cheat-sheet |
 
 Where the code lives:
 
-- Score math, both channels: [`monitor/pressure.py`](../monitor/pressure.py) (`PressureAnalyzer`)
+- Score math, system & disk channels: [`monitor/pressure.py`](../monitor/pressure.py) (`PressureAnalyzer`)
 - Per-disk USE model: [`monitor/disk_pressure.py`](../monitor/disk_pressure.py) (`DiskIOMonitor`)
+- Network channel (signals, smoothing, score): [`monitor/network.py`](../monitor/network.py) (`NetworkMonitor`)
 - Signal collection & attribution: [`monitor/psi.py`](../monitor/psi.py) (`PSIMonitor`)
 - Orchestration / refresh cadence: [`monitor/monitor_api.py`](../monitor/monitor_api.py) (`SystemPressureMonitor`)
 
@@ -640,6 +645,301 @@ allowed at all.
 
 ---
 
+# Part IV — The network channel
+
+## 16. Why network needs its own channel
+
+Network pressure lives entirely outside the system and disk channels: there is no NIC term
+in the system `load`, and the balancer's traffic shaper needs a **per-direction** trigger
+(egress and ingress are throttled independently, on different qdiscs). So the network
+channel is a third parallel pipeline with its own model, its own bands (`network_thresholds`,
+never the system `thresholds`), and — unlike the other two — its own **signal-level**
+smoothing instead of the §4 score→level filter.
+
+It also answers a question the other channels never face: **is "busy" the same as "under
+pressure"?** For a disk, high utilisation with low latency is genuinely fine. For a link it
+is subtler — a NIC at 95 % of line rate with zero loss is merely busy, while a NIC dropping
+packets at 60 % (because the CPU cannot drain the softirq backlog) is in real trouble. The
+old model scored on utilisation alone and got this exactly backwards. The rule now:
+
+> **Distress (drops / queue backlog) is the pressure. Utilisation only counts once it is
+> genuinely near line rate.**
+
+```mermaid
+flowchart TD
+    A["/sys/class/net/&lt;if&gt;/statistics<br/>bytes, packets, dropped, fifo+missed+over"] --> U
+    A --> R
+    P["/proc/net/softnet_stat<br/>processed, squeeze, drop (system-wide × pkt-share)"] --> R
+    U["ema_bw_util, ema_pps_util<br/>(dt-aware EMA)"] --> B["base_load = max(bw, pps)"]
+    B --> G["util_sat = σ(base_load)<br/>steep gate ~0.96"]
+    R["drop / fifo / softnet ratios<br/>(window-diff, rate-relative)"] --> D["distress = noisy-OR of _sat(ratio)"]
+    D --> C["capacitor: max(decay·prev, distress)"]
+    G --> S["score = noisy-OR(util_sat, distress)"]
+    C --> S
+    S --> O["per-direction level via network_thresholds<br/>tx critical ⇒ egress shape · rx critical ⇒ ingress shape"]
+```
+
+Everything below is per interface and per direction (`rx`, `tx`), producing a score in
+`[0, 1]`. `softnet_stat` is the one exception — it is a system-wide receive-path signal, so
+it is read once and attributed to the **rx** direction only.
+
+---
+
+## 17. Utilisation — dt-aware EMA, two ceilings
+
+Two utilisation ratios are computed each sample and smoothed, then combined by `max`:
+
+$$
+\text{base\_load} = \max(\text{ema\_bw\_util},\ \text{ema\_pps\_util})
+$$
+
+| Ratio | Numerator | Denominator |
+|---|---|---|
+| `bw_util` | Δbytes · 8 / Δt (bit/s) | link bandwidth (`bandwidth_kbit`) |
+| `pps_util` | Δpackets / Δt (pkt/s) | `min(physical_max_pps, cpu_pps)` |
+
+- **Two ceilings for pps.** `physical_max_pps = speed_gbps · 1 488 095` (64-byte-frame line
+  rate) catches a **small-packet flood** that a NIC hits well before its byte bandwidth;
+  `cpu_pps = cores · cpu_pps_per_core` (default 1.5 M/core) caps it at what the host can
+  actually service in softirq. The lower of the two wins.
+- **`bandwidth_kbit = 0` means "unknown"** (virtual / bond / wifi interfaces report `-1` for
+  speed). In that case the byte term is dropped — the channel scores on pps and distress
+  only, rather than pretending a 1 Gbit link and pinning `bw_util` at 100 %.
+- **The EMA is dt-aware.** The balancer samples cheaply every tick but classifies only every
+  few seconds, so the smoothing constant is converted to the real gap:
+  $\alpha_{\text{eff}} = 1 - (1-\alpha)^{\Delta t}$. This gives the same time constant
+  whether the gap is 1 s or 5 s — a plain fixed-$\alpha$ EMA (or the old count-mean sliding
+  window) is biased by the irregular cadence. Utilisation is a continuous quantity, so EMA is
+  the right smoother: recency-weighted, no window drop-out sawtooth.
+
+---
+
+## 18. Distress — rate-relative, window-diff ratios
+
+Drops and queue events are **sparse and bursty**, so they are handled differently from
+utilisation: as **ratios over a 5 s window** (`WindowDiffHistory`), not an EMA of a raw
+count. A ratio needs a denominator accumulated over a window; an EMA of "packets dropped
+this tick" would be meaningless.
+
+Each ratio is squashed into `[0, 1)` by a saturating map, where `half` is the ratio that
+reads ~0.63 — the "starts to hurt" point:
+
+$$
+\text{sat}(r) = 1 - e^{-r / r_{1/2}}
+$$
+
+| Signal | Ratio | `half` (default) | Max weight | Direction |
+|---|---|---|---:|---|
+| generic RX drops | Δrx_dropped / Δrx_packets | built-in `5e-2` | 0.3 (configured) | rx |
+| TX packet drops | Δtx_dropped / Δtx_packets | `drop_half = 1e-3` | 1.0 | tx |
+| hardware overflow | Δ(fifo+missed+over) / Δpackets | `fifo_half = 1e-4` | 1.0 | rx (fifo only for tx) |
+| softnet squeeze | Δtime_squeeze / Δprocessed · share | `softnet_half = 1e-3` | 0.5 (built-in) | **rx only** |
+| softnet backlog drop | Δdropped / Δprocessed · share | `softnet_half = 1e-3` | 1.0 | **rx only** |
+
+The terms are fused with a noisy-OR (§12), so any one strong signal lifts `distress`
+without a single one pinning it:
+
+$$
+\text{distress} = 1 - \!\!\prod_{\text{terms}}\!\! \bigl(1 - \text{sat}(r_i)\bigr)
+$$
+
+- **Generic RX drops ramp more slowly than TX drops.** `rx_dropped` has driver/stack-specific
+  semantics and is capped at half-strength, so its 5% half-point distinguishes moderate loss
+  from catastrophic loss instead of making both immediately read as 50% pressure.
+- **`fifo_half` is 10× tighter than `drop_half`.** A ring-buffer overflow is a harder failure
+  than a software drop, so a smaller ratio should already read as pressure.
+- **The hardware-overflow ratio sums `rx_fifo_errors + rx_missed_errors + rx_over_errors`.**
+  The same "NIC couldn't hand the packet to the host in time" failure lands in different
+  fields across drivers — on many Intel NICs (igb/ixgbe/e1000e) the ran-out-of-descriptors
+  drop is counted in `rx_missed_errors` while `rx_fifo_errors` stays 0, so reading fifo alone
+  would miss it. tx has no sysfs equivalent, so tx keeps `tx_fifo_errors` alone.
+- **softnet is rx-only** because `/proc/net/softnet_stat` measures the *receive* softirq path
+  (budget exhausted, backlog full). It is the signal that catches "the CPU cannot keep up
+  with inbound packets" — which pure byte/packet rate never sees.
+- **softnet squeeze is capped at half-strength per NIC.** It says the kernel exhausted a
+  receive-softirq budget, a strong warning but not proof of loss. `softnet dropped` remains
+  full-strength because it proves the backlog filled and packets were discarded. The separate
+  system-wide `softirq_harm` signal used by the TX PPS gate remains full-strength so it still
+  catches a harmful egress small-packet flood.
+- **softnet is attributed to this NIC by packet share.** `softnet_stat` is system-wide (every
+  interface shares the rx softirq path), so its two terms are scaled by
+  `share = Δrx_packets / Δsoftnet_processed` before entering the noisy-OR. A single-NIC box
+  has `share ≈ 1` (unchanged), but on a machine where another NIC — or loopback/bridge
+  traffic — drives the softirq load, this NIC no longer inherits that pressure and trips an
+  ineffective ingress shape. Per-queue sysfs (`queues/rx-*`) exposes no drop/squeeze
+  counters, so packet share is the attribution available without per-driver `ethtool -S`.
+
+### The distress capacitor
+
+A raw 5 s window makes a burst vanish abruptly the moment it ages out. Instead, distress is
+held through a **dt-aware decaying-max** so it cools smoothly:
+
+$$
+\text{distress}_t = \max\bigl(\text{distress}_{t-1}\cdot \text{decay}^{\,\Delta t},\ \ \text{distress}_{\text{instant}}\bigr)
+$$
+
+`decay_rate` (default `0.7`) is the fraction retained per second, so a spike to 1.0 decays to
+~0.7 after 1 s, ~0.24 after 4 s — long enough to survive the gap between classifications,
+short enough to clear once the drops stop.
+
+### The activity gate — don't trust a ratio without a denominator
+
+A ratio is only meaningful once its denominator is real. On a **near-idle** direction the
+window's packet/processed count is tiny, so a handful of stray drops — or system-wide softnet
+squeeze bleeding in from a busy *other* path (a TX small-packet flood is the canonical case) —
+inflates the ratio to ~1 and trips a **false `critical`**. So each direction's distress is
+scaled by an activity gate:
+
+$$
+\text{act}_d = \min\!\Bigl(1,\ \frac{\text{pps}_d}{\text{min\_pps\_activity}}\Bigr),
+\qquad \text{distress}_d \mathrel{{\times}{=}} \text{act}_d
+$$
+
+`min_pps_activity` (default **2000** pkt/s) is the rate below which loss is not trusted: an
+idle direction reads ~0 distress no matter how large the ratio, while a genuine high-pps flood
+(`act ≈ 1`) still registers its real loss. This is what stops a TX flood — which drives
+system-wide softnet squeeze — from tripping a bogus rx `critical` on an otherwise idle receive
+path. The raw pre-gate ratios are still surfaced for diagnostics (the Network card shows the
+actual drop/overflow/softnet rate behind a reading), and the **ungated** softnet saturation is
+kept separately as `softirq_harm` — the commons signal §21 uses, precisely because it must
+survive the rx gate to catch an idle-rx TX flood.
+
+---
+
+## 19. The score — a saturation gate, then noisy-OR
+
+Utilisation must **not** reach the throttle band on its own until the link is genuinely near
+line rate. So `base_load` is passed through a steep logistic gate before it can contribute:
+
+$$
+\text{util\_sat} = \sigma(\text{base\_load}) = \frac{1}{1 + e^{-k(\text{base\_load} - h)}},
+\qquad h = 0.96,\ k = 120
+$$
+
+$$
+\boxed{\ \text{score} = 1 - (1 - \text{util\_sat})(1 - \text{distress})\ }
+$$
+
+With the shipped gate, clean-link utilisation maps like this (`distress = 0`):
+
+| `base_load` | `util_sat` = score | reading |
+|---|---|---|
+| ≤ 0.90 | ≈ 0.00 | busy, not pressure |
+| 0.95 | **0.23** | below the `high` band (0.7) |
+| 0.96 | 0.50 | the half-point |
+| 0.98 | **0.92** | near saturation → `critical` |
+| 1.00 | 0.99 | pegged → `critical` |
+
+And distress drives the score regardless of utilisation:
+
+| `base_load` | `distress` | score | who drives |
+|---|---|---|---|
+| 0.30 | 0.00 | 0.00 | idle, clean |
+| 0.30 | 0.95 | **0.95** | **drops → `critical` at 30 % util** |
+| 0.98 | 0.00 | 0.92 | genuine saturation |
+| 0.60 | 0.60 | 0.84 | both contribute |
+
+The row that captures the whole redesign is **`0.30` util + drops → `0.95`**: a lightly
+loaded link that is losing packets is `critical`, while a clean link at 95 % is not even
+`high`.
+
+---
+
+## 20. What the level drives
+
+The per-direction scores go straight into `network_thresholds` via
+`PressureAnalyzer.get_pressure_level` (§4's classifier, but *without* the EWMA/hysteresis
+wrapper — the smoothing already happened at the signal level). `update_network_pressure_level`
+returns a level for each direction:
+
+| level | shaper behaviour (per direction) |
+|---|---|
+| `low` / `medium` / `high` | if currently throttled, **recover** one bandwidth stage (staged restore) |
+| `critical` | **throttle** one bandwidth stage — `tx critical` shapes egress, `rx critical` shapes ingress (on the IFB device) |
+
+Throttle and recovery each have their own cooldown, and the two directions run fully
+independent state machines. Because a clean-but-busy link no longer reaches `critical`
+(§19), utilisation alone will not trip shaping — only genuine saturation or a distress
+signal will.
+
+`get_current_pressure()` returns the two scores plus diagnostics — `rx_util` / `tx_util`
+(raw `base_load`, "how busy") and `rx_distress` / `tx_distress` (the congestion term, "how
+much it hurts") — so a log or the UI can show *why* a direction is or isn't under pressure.
+It also returns the **distress breakdown** (`rx_distress_drop/hw/softnet_squeeze/softnet_drop`,
+`tx_distress_drop/fifo`) and two **collective-harm** rollups
+(`rx_collective_harm`, `tx_collective_harm`) that §21 uses to pick the right remedy.
+
+---
+
+## 21. Relieving network pressure — matching the lever to the failure mode
+
+A high score says a direction is *under pressure*; it does **not** say *how to relieve it*.
+The score fuses two very different failure modes, and they need different levers:
+
+| Failure mode | Symptom | Right lever | Wrong lever |
+|---|---|---|---|
+| **byte / bandwidth saturation** | byte-rate at line rate, `*_util` high, distress low | HTB bandwidth shaping (the tier `ceil`) | — |
+| **packet-rate / CPU saturation** (small-packet flood) | pps high, `*_collective_harm` high (softnet/fifo/missed drops), bandwidth *low* | per-app **pps** limiting (egress) / softirq spreading (ingress) | HTB bandwidth shaping |
+
+HTB caps **bytes/s** at **tier-class** granularity. For a small-packet flood that is the
+wrong unit (bytes, not packets) at the wrong granularity (a whole priority tier, not the one
+offending app) — and on ingress it sits *downstream* of where the flood's drops happen
+(NIC ring / softirq), so it cannot relieve them at all.
+
+### The gate — `harm × attribution × priority`
+
+This is the network analog of the disk channel's `saturation × stall` (§13) and the model's
+"busy ≠ pressure" rule (§19). A high-pps app is only acted upon when **all three** hold:
+
+1. **attribution** — a specific app's pps is genuinely high (per-app accounting, below);
+2. **collective harm** — harm is over threshold, i.e. the flood is actually causing drops /
+   starving the softirq path, not just keeping the NIC busy. Harm is
+   `max(tx_collective_harm, softirq_harm)`: the TX byte-path signal (`tx_fifo`) **or** the
+   system-wide receive-softirq signal (`softirq_harm`, the ungated softnet saturation of
+   §18). The second is what catches a small-packet egress flood that burns the softirq
+   without ever producing a `tx_fifo` drop or lifting `tx_pressure` — so the TX pps gate
+   fires on softirq harm alone, `tx_pressure critical` is **not** required for this path;
+3. **priority** — the offender's tier rank is **below** a victim's. Priority decides who
+   yields: a `low` app harming a `high` app is throttled; a `critical` app is not (it is
+   supposed to win). Equal priority falls back to fairness (fq_codel, below).
+
+A flood that harms nobody stays untouched — that is the whole point of gating on *harm*, not
+on *volume*.
+
+### The three execution layers
+
+1. **Egress fairness (always on) — `fq_codel` leaf qdisc.** A per-flow-fair leaf under each
+   egress tier class means one flow cannot starve another's egress, with no per-app
+   accounting and no identification of an offender. Cheapest protection; handles the
+   equal-priority case. Egress only (fair-queueing already-admitted *inbound* packets does
+   nothing for a flood and adds redirect cost).
+2. **Egress targeting — per-app pps police (default OFF).** When the gate fires, a
+   packet-rate `police` action is attached to the offending app's own tc filter
+   (`tc filter replace … action police pkts_rate N pkts_burst M`), capping *that app's*
+   pps only. Reversible. Off by default because it drops packets and needs kernel ≥ 5.17.
+3. **Ingress escalation — RPS → (budget).** `tc` cannot relieve an inbound flood, so
+   harm-driven RX escalates instead of shaping: spread the receive softirq across cores via
+   **RPS** (`/sys/class/net/<if>/queues/rx-*/rps_cpus`, reversible; the primary action),
+  optionally raise `netdev_max_backlog`/`netdev_budget` (system-wide, opt-in). RX is about
+  protecting the **commons**,
+   not per-app arbitration — the byte-saturation RX case still uses the HTB ingress path.
+
+### Per-app attribution
+
+Each managed app already carries a unique `iptables … MARK`; its per-app **packet** counters
+come from `iptables -t mangle -nvxL OUTPUT` (keyed by cgroup path), turned into a windowed
+pps via `WindowDiffHistory`. This is what lets the gate name the offender — the aggregate
+per-NIC score cannot.
+
+### The honest RX limit
+
+Even with RPS, an inbound small-packet flood is only *mitigated*, not *shaped*: hardware
+ring drops (`rx_missed`/`rx_over`) happen before any software sees the packet, and the tc
+ingress hook runs *inside* the very softirq that is the bottleneck. RPS spreads the processing
+cost; a bandwidth cap never relieves that cost.
+
+---
+
 # Appendix — Parameter reference
 
 System channel and shared machinery:
@@ -673,6 +973,34 @@ Disk channel (Part III) — all under `config.yaml`, re-read every tick, no rest
 | `disk_pressure_model.activity_util_pct` | `20` % | more util required before await/queue count | idle-disk noise counts sooner |
 | `disk_pressure_model.max_p_weight` | `0.8` | the single worst disk dominates the aggregate | the mean dominates — **and caps `C`; below `1 − 0.2N/(N−1)` an N-disk box can never reach `critical`, so 0.8 is the safe floor** (§12) |
 
+Network channel (Part IV) — all under `config.yaml`, re-read every sample, no restart needed:
+
+| Parameter | Shipped | Increase it → | Decrease it → |
+|---|---|---|---|
+| `network_thresholds.{low,medium,high,critical}` | `0.3/0.5/0.7/0.9` | levels harder to reach | easier to reach |
+| `network_pressure_model.ema_alpha` | `0.3` | faster / noisier utilisation | smoother / laggier |
+| `network_pressure_model.decay_rate` | `0.7` | distress lingers longer after a burst | clears faster |
+| `network_pressure_model.cpu_pps_per_core` | `1 500 000` | pps ceiling rises (small-packet load reads as less pressure) | small-packet floods trip sooner |
+| `network_pressure_model.min_pps_activity` | `2 000` | a direction must be busier before its drop/softnet distress is trusted (fewer near-idle false positives, but a real low-rate loss registers later) | idle-link ratios count sooner (risk of low-denominator false `critical`) |
+| `network_pressure_model.{drop_half,fifo_half,softnet_half}` | `1e-3 / 1e-4 / 1e-3` | the same signal reads as **less** distress | as more distress |
+| `network_pressure_model.util_sat_half` | `0.96` | utilisation must be closer to line rate before it counts | busy links read as pressure sooner |
+| `network_pressure_model.util_sat_k` | `120` | sharper, more switch-like near saturation | gentler ramp (less line-rate jitter, but a wider "busy" grey zone) |
+
+Small-packet-flood policy (§21). `enable_app_pps_police` is the only user-facing switch in
+`config.yaml`; other safeguards use conservative controller defaults. State-mutating actions
+(`police`, sysctl) ship **OFF**:
+
+| Parameter | Shipped | Meaning |
+|---|---|---|
+| `enable_fq_codel` | `true` | per-flow-fair `fq_codel` leaf on egress tier classes (§21 layer 1) |
+| `enable_app_pps_police` | `false` | attach a per-app packet-rate `police` to the offending app (layer 2). Drops packets; needs kernel ≥ 5.17 (auto-disabled if unsupported) |
+| `enable_rps_escalation` | `true` | on RX collective harm, widen `rps_cpus` to spread the receive softirq (layer 3, primary) |
+| `enable_netdev_budget_bump` | `false` | also raise `netdev_max_backlog`/`netdev_budget` on RX harm. **System-wide**, hence opt-in |
+| `app_pps_high` | `50000` | per-app pps above which an app is a flood candidate. Raise → floods trip later |
+| `collective_harm_threshold` | `0.5` | `*_collective_harm` needed to act. Raise → only worse floods act |
+| `pps_cap_rate` / `pps_cap_burst` | `10000` / `2000` | the `police pkts_rate`/`pkts_burst` applied to a capped app |
+| `pps_window_sec` | `5` | window for the per-app pps rate |
+
 ## Tuning cheat-sheet
 
 - **"CPU-heavy jobs shouldn't trigger throttling"** — already handled by the normalized
@@ -701,3 +1029,27 @@ Disk channel (Part III) — all under `config.yaml`, re-read every tick, no rest
 - **"A USB disk / an HDD reads as permanently saturated"** — check `disk_type` in the
   `[disk-level]` line first (misdetected media applies the wrong half-points), then the
   half-points for that class.
+- **"A busy but healthy link keeps getting throttled"** — that was the old utilisation-only
+  behaviour; confirm `rx_distress` / `tx_distress` are ~0 and the score is coming from
+  `util_sat`. Raise `network_pressure_model.util_sat_half` (0.96 → 0.98) so only near-line-rate
+  utilisation counts.
+- **"Packet loss isn't triggering pressure"** — read `rx_distress` / `tx_distress`. If TX loss
+  is real but distress stays low, lower the relevant `*_half` (TX drops → `drop_half`, ring
+  overflow → `fifo_half`, inbound softirq backlog → `softnet_half`); a smaller half-point
+  makes the same loss ratio read as more pressure. Generic RX-drop sensitivity is deliberately
+  built into the model because its driver/stack-specific semantics cannot be safely tuned as a
+  universal deployment setting.
+- **"Small-packet flood pins the link but score is low"** — the byte term is near zero; check
+  whether pps is hitting its ceiling. Lower `network_pressure_model.cpu_pps_per_core` if the
+  host saturates softirq before the advertised line-rate pps.
+- **"Network level flaps near line rate"** — the saturation gate is too steep for a link that
+  hovers at ~0.96; lower `network_pressure_model.util_sat_k` (120 → 60) for a gentler ramp, or
+  raise `ema_alpha`'s smoothing by lowering it.
+- **"A small-packet flood is critical but nothing throttles it"** — that is §21 working, not a
+  bug: a bandwidth cap is the wrong lever. On TX enable `enable_app_pps_police`
+  (kernel ≥ 5.17) to cap the offending app's pps; on RX rely on RPS. Read
+  `tx_collective_harm` / `rx_collective_harm` — if they are ~0 the flood is
+  not actually hurting anyone (the gate deliberately holds off).
+- **"The flood's app isn't being singled out"** — the gate needs per-app attribution and a
+  higher-priority victim. Check the app's pps against `network_pps_policy.app_pps_high` and that a
+  higher-priority app is present; equal-priority contention is handled by `fq_codel`, not policing.

--- a/monitor/metrics/history.py
+++ b/monitor/metrics/history.py
@@ -283,6 +283,12 @@ def _build_network_history(network: Dict[str, Any]) -> Dict[str, Any]:
 
     utilization_percent = max(all_nic_utils) if all_nic_utils else None
 
+    # Per-NIC, per-direction pressure diagnostics (packet loss / congestion).
+    # Kept alongside the network section so a network-only monitored set still
+    # persists loss/congestion history; the UI reads it as a fallback when the
+    # pressure section is not present.
+    pressure_interfaces = network.get("pressure_interfaces") if isinstance(network, dict) else None
+
     return {
         "total": {
             "rx_bytes_per_sec": rx_bytes,
@@ -291,6 +297,7 @@ def _build_network_history(network: Dict[str, Any]) -> Dict[str, Any]:
         "total_mbps": round(total_mbps, 3) if total_mbps is not None else None,
         "utilization_percent": round(utilization_percent, 3) if utilization_percent is not None else None,
         "per_nic": per_nic,
+        "pressure_interfaces": pressure_interfaces if isinstance(pressure_interfaces, dict) else {},
     }
 
 
@@ -339,7 +346,16 @@ def _build_dynamic_history_payload(data: Dict[str, Any]) -> Dict[str, Any]:
             "network_total_nics": pressure.get("network_total_nics"),
             "network_busy_ratio": to_float(pressure.get("network_busy_ratio")),
             "network_busy_pct": to_float(pressure.get("network_busy_pct")),
-            "network_busy_level": pressure.get("network_busy_level"),
+            "network_pressure_level": pressure.get("network_pressure_level"),
+            "network_pressure_pct": to_float(pressure.get("network_pressure_pct")),
+            "network_worst_nic": pressure.get("network_worst_nic"),
+            "network_worst_direction": pressure.get("network_worst_direction"),
+            # Per-NIC, per-direction diagnostics (drop_ratio_pct = packet loss,
+            # distress_pct = congestion). Persisted verbatim so the history
+            # Network chart can plot the same loss/congestion series the live
+            # card shows; without this the chart's loss/congestion lines are
+            # empty because the source data was dropped before storage.
+            "network_interfaces": pressure.get("network_interfaces") or {},
         }
 
     if "disk" in data:

--- a/monitor/monitor_api.py
+++ b/monitor/monitor_api.py
@@ -24,6 +24,10 @@ from monitor.app_discovery import is_noise_process
 # by it, so it is imported rather than restated -- a copy would drift the moment a class is
 # added there.
 from monitor.disk_pressure import MEDIA_CLASSES as _DISK_MEDIA_CLASSES
+from monitor.network_pressure import (
+    start_network_pressure_collector,
+    stop_network_pressure_collector,
+)
 from utils.app_utils import get_cgroup_path_by_pid
 from utils.http_utils import RetCode, construct_response
 from utils.logger import logger
@@ -162,6 +166,10 @@ def _start_dynamic_info_auto_refresh() -> None:
     lazily by the full endpoint as a dev/test self-start fallback.
     """
     global _dynamic_info_refresh_started, _dynamic_info_collector_thread
+    # In monitor-only mode there is no balancer network loop to feed
+    # network-pressure snapshots, so start the monitor-side sampler here.
+    if _network_config_reload_notifier is None:
+        start_network_pressure_collector()
     with _dynamic_info_refresh_start_lock:
         if _dynamic_info_refresh_started or not _get_monitored_sections():
             return
@@ -180,11 +188,15 @@ def stop_dynamic_info_collector() -> None:
     global _dynamic_info_refresh_started
     with _dynamic_info_refresh_start_lock:
         if not _dynamic_info_refresh_started:
+            # Even without a dynamic-info thread, a monitor-only service may
+            # still have the network-pressure sampler running.
+            stop_network_pressure_collector()
             return
         _dynamic_info_refresh_started = False
     _dynamic_info_stop_event.set()
     if _dynamic_info_collector_thread is not None:
         _dynamic_info_collector_thread.join(timeout=2)
+    stop_network_pressure_collector()
 
 
 def _start_app_stats_auto_refresh() -> None:
@@ -823,6 +835,11 @@ class SystemPressureMonitor:
         try:
             tx_level = self.analyzer.get_pressure_level(network_data['tx'], self.config.network_thresholds)
             rx_level = self.analyzer.get_pressure_level(network_data['rx'], self.config.network_thresholds)
+            # Generic drops and squeeze show pressure, not necessarily an RX
+            # capacity failure that ingress control can correct. Reserve RX critical
+            # for hardware/ring or softnet-backlog exhaustion.
+            if rx_level == "critical" and not network_data.get("rx_capacity_exhausted", False):
+                rx_level = "high"
             return tx_level, rx_level, network_data['tx'], network_data['rx']
         except Exception as e:
             logger.error("Failed to update network pressure level: %s", str(e))
@@ -2168,31 +2185,63 @@ def _write_disk_pressure_config(updates):
 
 # --- network_pressure: network utilisation level cut-offs --------------------
 def _get_network_pressure_config():
-    return {"network_thresholds": dict(_cfg().network_thresholds or {})}
+    model = getattr(_cfg(), "network_pressure_model", None)
+    model_dict = model if isinstance(model, dict) else {}
+    return {
+        "network_thresholds": dict(_cfg().network_thresholds or {}),
+        "network_pressure_model": {
+            "rx_drop_weight": float(model_dict.get("rx_drop_weight", 0.5)),
+        },
+    }
 
 
 def _validate_network_pressure_config(body):
-    thresholds_body = body.get("network_thresholds")
-    if not isinstance(thresholds_body, dict):
-        raise ValueError("network_thresholds must be an object")
+    updates = {}
 
-    thresholds = {}
-    for key in _THRESHOLD_KEYS:
-        if key in thresholds_body and thresholds_body[key] is not None:
-            value = float(thresholds_body[key])
-            if not (0 < value <= 1):
-                raise ValueError(f"network threshold {key} must be within (0, 1]")
-            thresholds[key] = value
+    if "network_thresholds" in body:
+        thresholds_body = body.get("network_thresholds")
+        if not isinstance(thresholds_body, dict):
+            raise ValueError("network_thresholds must be an object")
 
-    merged = {**(_cfg().network_thresholds or {}), **thresholds}
-    ordered = [merged[key] for key in _THRESHOLD_KEYS if merged.get(key) is not None]
-    if len(ordered) != len(_THRESHOLD_KEYS) or ordered != sorted(ordered):
-        raise ValueError("network_thresholds must be ordered low <= medium <= high <= critical")
-    return {"network_thresholds": thresholds}
+        thresholds = {}
+        for key in _THRESHOLD_KEYS:
+            if key in thresholds_body and thresholds_body[key] is not None:
+                value = float(thresholds_body[key])
+                if not (0 < value <= 1):
+                    raise ValueError(f"network threshold {key} must be within (0, 1]")
+                thresholds[key] = value
+
+        merged = {**(_cfg().network_thresholds or {}), **thresholds}
+        ordered = [merged[key] for key in _THRESHOLD_KEYS if merged.get(key) is not None]
+        if len(ordered) != len(_THRESHOLD_KEYS) or ordered != sorted(ordered):
+            raise ValueError("network_thresholds must be ordered low <= medium <= high <= critical")
+        updates["network_thresholds"] = thresholds
+
+    if "network_pressure_model" in body:
+        model_body = body.get("network_pressure_model")
+        if not isinstance(model_body, dict):
+            raise ValueError("network_pressure_model must be an object")
+        model_updates = {}
+        if "rx_drop_weight" in model_body and model_body["rx_drop_weight"] is not None:
+            value = float(model_body["rx_drop_weight"])
+            if not (0 <= value <= 1):
+                raise ValueError("network_pressure_model.rx_drop_weight must be within [0, 1]")
+            model_updates["rx_drop_weight"] = value
+        if model_updates:
+            updates["network_pressure_model"] = model_updates
+
+    if not updates:
+        raise ValueError("No valid network_pressure updates provided")
+    return updates
 
 
 def _write_network_pressure_config(updates):
-    return _cfg().update_config_section("network_thresholds", updates["network_thresholds"])
+    modified = False
+    if "network_thresholds" in updates:
+        modified = _cfg().update_config_section("network_thresholds", updates["network_thresholds"]) or modified
+    if "network_pressure_model" in updates:
+        modified = _cfg().update_config_section("network_pressure_model", updates["network_pressure_model"]) or modified
+    return modified
 
 
 # --- limit_policy: full nested policy + per-resource enable/rate --------------
@@ -2346,9 +2395,17 @@ def _get_network_control_config():
         }
         for key in _NETWORK_PRIORITIES
     }
+    raw_pps_policy = getattr(cfg, "network_pps_policy", None)
+    pps_policy = raw_pps_policy if isinstance(raw_pps_policy, dict) else {}
     return {
         "enable_network_control": bool(getattr(cfg, "enable_network_control", False)),
         "enable_network_pressure_shaping": bool(getattr(cfg, "enable_network_pressure_shaping", True)),
+        "enable_app_pps_police": bool(getattr(cfg, "enable_app_pps_police", False)),
+        "network_pps_policy": {
+            "app_pps_high": int(pps_policy.get("app_pps_high", 50000)),
+            "pps_cap_rate": int(pps_policy.get("pps_cap_rate", 10000)),
+            "pps_cap_burst": int(pps_policy.get("pps_cap_burst", 2000)),
+        },
         "available_network_interfaces": available_nics,
         "selected_network_interfaces": selected_nics,
         "config_network_bw": class_bw,
@@ -2371,6 +2428,37 @@ def _validate_network_control_config(body):
 
     if "enable_network_pressure_shaping" in body:
         updates["enable_network_pressure_shaping"] = bool(body.get("enable_network_pressure_shaping"))
+
+    if "enable_app_pps_police" in body:
+        updates["enable_app_pps_police"] = bool(body.get("enable_app_pps_police"))
+
+    pps_body = body.get("network_pps_policy")
+    if pps_body is not None:
+        if not isinstance(pps_body, dict):
+            raise ValueError("network_pps_policy must be an object")
+        pps_updates = {}
+        for key in ("app_pps_high", "pps_cap_rate", "pps_cap_burst"):
+            if key not in pps_body or pps_body[key] is None:
+                continue
+            try:
+                value = int(pps_body[key])
+            except (TypeError, ValueError):
+                raise ValueError(f"network_pps_policy.{key} must be a positive integer")
+            if value <= 0:
+                raise ValueError(f"network_pps_policy.{key} must be a positive integer")
+            pps_updates[key] = value
+        if pps_updates:
+            current_policy = getattr(_cfg(), "network_pps_policy", None)
+            merged_policy = {
+                "app_pps_high": 50000,
+                "pps_cap_rate": 10000,
+                "pps_cap_burst": 2000,
+                **(current_policy if isinstance(current_policy, dict) else {}),
+                **pps_updates,
+            }
+            if merged_policy["pps_cap_rate"] > merged_policy["app_pps_high"]:
+                raise ValueError("network_pps_policy.pps_cap_rate must not exceed app_pps_high")
+            updates["network_pps_policy"] = pps_updates
 
     if "selected_network_interfaces" in body and not disabling_network_control:
         from monitor.system_info import _get_network_static_info

--- a/monitor/network.py
+++ b/monitor/network.py
@@ -1,16 +1,101 @@
 # Copyright (c) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+"""NIC pressure: a per-direction [0, 1] score fusing utilisation *load* with congestion
+*distress*::
+
+    base_load = max(ema_bw_util, ema_pps_util)          # smoothed load
+    util_sat  = sigmoid(base_load, half~0.96, k~120)    # only near line rate -> pressure
+    distress  = noisy_or(drop, fifo, softnet)           # rate-relative pain, [0, 1]
+    score     = noisy_or(util_sat, distress)
+
+Distress (drops / queue backlog) is the primary signal: a link dropping packets at 60%
+utilisation is in trouble, while a clean link at 95% is merely busy -- utilisation only
+counts once it is genuinely near line rate.
+
+Smoothing differs by signal type: utilisation is a dt-aware EMA (continuous, robust to the
+irregular sample cadence), while drops/fifo/softnet are window-diff *ratios*
+(delta_event / delta_packets) -- the right form for sparse bursty events -- held through a
+decaying-max "capacitor" so a burst cools smoothly instead of vanishing when it leaves the
+window.
+
+softnet_stat is system-wide (the receive softirq path), so it is attributed to the rx
+direction and scaled by this NIC's share of system rx packets. Each direction's distress is
+also scaled by an activity gate ``min(1, pps/min_pps_activity)`` so a near-idle direction
+(tiny ratio denominator) cannot false-trip on a handful of stray drops.
+
+Model constants are live-overridable from ``config.network_pressure_model`` via
+:meth:`NetworkMonitor._model`. See ``docs/pressure_algorithm.md`` Part IV.
+"""
+
+import math
 import os
 import time
 from typing import Dict, Optional
 from utils.logger import logger
 
-# [SECURITY REVIEW]: All subprocess calls in this module use list-based arguments 
-# with shell=False (default). No untrusted shell execution or string 
+from config.config import b_config
+
+# [SECURITY REVIEW]: All subprocess calls in this module use list-based arguments
+# with shell=False (default). No untrusted shell execution or string
 # concatenation is performed. All inputs are internally validated.
 import subprocess # nosec
 import re
+
+
+# --- math helpers ------------------------------------------------------------
+def _clamp01(x: float) -> float:
+    if x <= 0.0:
+        return 0.0
+    return 1.0 if x >= 1.0 else x
+
+
+def _sat(ratio: float, half: float) -> float:
+    """Saturating map of a non-negative ratio into [0, 1): ``1 - exp(-ratio/half)``.
+    ``half`` is the ratio at which the term reads ~0.63 -- the "starts to hurt" point."""
+    if ratio <= 0.0:
+        return 0.0
+    return 1.0 - math.exp(-ratio / half)
+
+
+def _sigmoid(x: float, half: float, k: float) -> float:
+    """Logistic gate in (0, 1): ``1 / (1 + exp(-k*(x-half)))``. ``half`` is the input that
+    reads 0.5, ``k`` the steepness. Used to squash utilisation so only *near-saturation*
+    reads as pressure -- a busy-but-clean link is not distress."""
+    z = -k * (x - half)
+    if z >= 60.0:
+        return 0.0
+    if z <= -60.0:
+        return 1.0
+    return 1.0 / (1.0 + math.exp(z))
+
+
+def _noisy_or(*vals: float) -> float:
+    """Probabilistic OR: ``1 - prod(1 - v)``. Any strong signal pulls the result up
+    without a single one pinning it."""
+    prod = 1.0
+    for v in vals:
+        prod *= (1.0 - _clamp01(v))
+    return 1.0 - prod
+
+
+def _read_softnet_stats() -> Dict[str, int]:
+    """Aggregate ``/proc/net/softnet_stat`` across CPUs. System-wide (receive softirq
+    path), NOT per-NIC. Columns (hex): [0]=packets processed, [1]=dropped (backlog full),
+    [2]=time_squeeze (budget/timeslice exhausted before the queue drained)."""
+    processed = squeezed = dropped = 0
+    try:
+        with open("/proc/net/softnet_stat") as f:
+            for line in f:
+                cols = line.split()
+                if len(cols) >= 3:
+                    processed += int(cols[0], 16)
+                    dropped += int(cols[1], 16)
+                    squeezed += int(cols[2], 16)
+    except (FileNotFoundError, ValueError, OSError):
+        pass
+    return {"processed": processed, "squeezed": squeezed, "dropped": dropped}
+
 
 class WindowDiffHistory:
     def __init__(self, window_sec=5, fields=None):
@@ -35,83 +120,310 @@ class WindowDiffHistory:
         end = self._history[-1]
         delta_num = end[num_idx] - start[num_idx]
         delta_denom = end[denom_idx] - start[denom_idx]
-        return delta_num / delta_denom if delta_denom > 0 else 0.0
+        # Guard counter resets/wraps (interface down/up): a negative delta is not a rate.
+        if delta_denom <= 0 or delta_num < 0:
+            return 0.0
+        return delta_num / delta_denom
 
 class NetworkMonitor:
-    """
-    Pressure is defined as the NIC utilisation in a given time window, normalised to [0, 1].
-    """
+    """Per-direction NIC pressure in [0, 1]: utilisation load fused with congestion distress."""
     _NET_PATH = "/sys/class/net/{}/statistics/{}"
     _BANDWIDTH_KBIT = 1000000  # NIC bandwidth in kbit/s (e.g. 1Gbps = 1000000 kbit/s)
     _WINDOW_SEC = 5
 
-    def __init__(self, interface: str = "enp1s0", bandwidth_kbit: int = None):
+    # --- model defaults (all live-overridable via config.network_pressure_model) -----
+    _EMA_ALPHA = 0.3            # per-1s smoothing factor for the utilisation EMA
+    _DECAY_RATE = 0.7           # fraction of distress retained per second (capacitor)
+    _CPU_PPS_PER_CORE = 1_500_000.0  # rough per-core softirq packet budget (small-pkt cap)
+    # Packet rate (pkt/s) below which a direction's distress ratio is not trusted: on a
+    # near-idle direction the denominator is tiny, so a few stray drops would trip a false
+    # "critical". Distress is scaled by min(1, pps/_MIN_PPS_ACTIVITY) (the activity gate).
+    _MIN_PPS_ACTIVITY = 2000.0
+    _DROP_HALF = 1e-3          # TX drop ratio half-point; TX drops are direct egress pressure
+    # Generic rx_dropped has driver/stack-specific semantics -> wider curve than TX drops.
+    _RX_DROP_HALF = 5e-2
+    _RX_DROP_WEIGHT = 0.5      # generic rx_dropped is evidence, not direct capacity exhaustion
+    _FIFO_HALF = 1e-4          # fifo (ring overflow) ratio half-point -- rarer, so smaller
+    _SOFTNET_HALF = 1e-3       # softnet squeeze/drop ratio half-point
+    # A squeeze means softirq exhausted its budget, not necessarily that it dropped packets:
+    # a strong warning, but not enough to peg the RX score on its own.
+    _SOFTNET_SQUEEZE_WEIGHT = 0.5
+    _PPS_PER_GBPS = 1_488_095  # 64-byte-frame line rate: packets/s per Gbit/s
+    # Utilisation saturation gate (`half`=0.5 point, `k`=steepness): only near-line-rate
+    # utilisation reads as pressure. ~0.95 -> ~0.23, ~0.98 -> ~0.92, <0.90 -> ~0.
+    _UTIL_SAT_HALF = 0.96
+    _UTIL_SAT_K = 120.0
+
+    # sysfs counters read every sample. The three rx hardware-drop fields are summed into one
+    # overflow signal below because the "NIC couldn't hand the packet to the host in time"
+    # failure lands in different fields across drivers (many Intel NICs use rx_missed_errors
+    # while rx_fifo_errors stays 0). tx has no sysfs equivalent, so it keeps tx_fifo_errors.
+    _COUNTER_FIELDS = (
+        "rx_bytes", "tx_bytes", "rx_packets", "tx_packets",
+        "rx_dropped", "tx_dropped", "rx_fifo_errors", "tx_fifo_errors",
+        "rx_missed_errors", "rx_over_errors",
+    )
+
+    def __init__(self, interface: str = "enp1s0", bandwidth_kbit: int = None, config=None):
+        self.config = config or b_config
         self.interface = interface
-        self.bandwidth_kbit = bandwidth_kbit or self._BANDWIDTH_KBIT
-        self._last_rx = None
-        self._last_tx = None
+        # `None` -> default; an explicit 0 means "bandwidth unknown" (virtual/bond/wifi),
+        # which drops the bandwidth-util term rather than pretending a 1 Gbit link.
+        self.bandwidth_kbit = self._BANDWIDTH_KBIT if bandwidth_kbit is None else bandwidth_kbit
+        self._cpu_cores = os.cpu_count() or 1
+        self._speed_warned = False
+
+        # Raw baseline from the previous sample.
+        self._last_counters = None
+        self._last_softnet = None
         self._last_time = None
-        self._pressure_history_rx = []
-        self._pressure_history_tx = []
-        # Packet-drop stats: (timestamp, packets, errors)
-        self._rx_drop_history = WindowDiffHistory(self._WINDOW_SEC, fields=["packets", "errors"])
-        self._tx_drop_history = WindowDiffHistory(self._WINDOW_SEC, fields=["packets", "errors"])
-        # Retransmission stats: (timestamp, retrans, outsegs)
-        self._retrans_history = WindowDiffHistory(self._WINDOW_SEC, fields=["retrans", "outsegs"])
 
-    def _get_net_bytes(self):
-        rx_path = self._NET_PATH.format(self.interface, "rx_bytes")
-        tx_path = self._NET_PATH.format(self.interface, "tx_bytes")
+        # Per-direction smoothed state.
+        self._ema_bw = {"rx": None, "tx": None}
+        self._ema_pps = {"rx": None, "tx": None}
+        self._distress = {"rx": 0.0, "tx": 0.0}
+        self._score = {"rx": 0.0, "tx": 0.0}
+        # Instant per-source distress components + collective-harm rollups, populated each
+        # sample by _update_pressure. Diagnostics only; the fused score is unchanged.
+        self._distress_components = {
+            "rx_drop": 0.0, "rx_hw": 0.0, "rx_softnet_squeeze": 0.0, "rx_softnet_drop": 0.0,
+            "tx_drop": 0.0, "tx_fifo": 0.0,
+            "rx_collective_harm": 0.0, "tx_collective_harm": 0.0,
+            "rx_capacity_exhausted": False,
+            "softirq_harm": 0.0,
+            "rx_drop_ratio": 0.0, "rx_hw_ratio": 0.0,
+            "rx_softnet_squeeze_ratio": 0.0, "rx_softnet_drop_ratio": 0.0,
+            "tx_drop_ratio": 0.0, "tx_fifo_ratio": 0.0,
+            "rx_pps": 0.0, "tx_pps": 0.0,
+        }
+
+        # Window-diff histories over *cumulative* counters -> rate-relative ratios.
+        # rx tuple layout: (timestamp, packets, dropped, hw_overflow=fifo+missed+over)
+        # tx tuple layout: (timestamp, packets, dropped, fifo)
+        self._rx_drop_history = WindowDiffHistory(self._WINDOW_SEC, fields=["packets", "dropped", "hw_overflow"])
+        self._tx_drop_history = WindowDiffHistory(self._WINDOW_SEC, fields=["packets", "dropped", "fifo"])
+        # system-level; tuple layout: (timestamp, processed, squeezed, dropped)
+        self._softnet_history = WindowDiffHistory(self._WINDOW_SEC, fields=["processed", "squeezed", "dropped"])
+
+    # --- config-overridable model ------------------------------------------------
+    def _model(self) -> Dict[str, float]:
+        """Live view of ``config.network_pressure_model`` merged over the class defaults.
+
+        Read every tick (not cached) so a config.yaml edit takes effect on the next sample;
+        any missing/malformed key falls back to the shipped default.
+        """
+        cfg = getattr(self.config, "network_pressure_model", None) or {}
+
+        def _num(key, default):
+            v = cfg.get(key)
+            return float(v) if isinstance(v, (int, float)) and not isinstance(v, bool) else default
+
+        def _weight(key, default):
+            value = _num(key, default)
+            return value if 0.0 <= value <= 1.0 else default
+
+        return {
+            "ema_alpha": _num("ema_alpha", self._EMA_ALPHA),
+            "decay_rate": _num("decay_rate", self._DECAY_RATE),
+            "cpu_pps_per_core": _num("cpu_pps_per_core", self._CPU_PPS_PER_CORE),
+            "min_pps_activity": _num("min_pps_activity", self._MIN_PPS_ACTIVITY),
+            "drop_half": _num("drop_half", self._DROP_HALF),
+            "rx_drop_weight": _weight("rx_drop_weight", self._RX_DROP_WEIGHT),
+            "fifo_half": _num("fifo_half", self._FIFO_HALF),
+            "softnet_half": _num("softnet_half", self._SOFTNET_HALF),
+            "util_sat_half": _num("util_sat_half", self._UTIL_SAT_HALF),
+            "util_sat_k": _num("util_sat_k", self._UTIL_SAT_K),
+        }
+
+    # --- counter reads -----------------------------------------------------------
+    def _read_stat(self, field: str) -> int:
+        """Read one sysfs statistics counter. Missing/unparseable (virtual NICs omit some)
+        degrades to 0 so a partial driver never breaks scoring."""
+        path = self._NET_PATH.format(self.interface, field)
         try:
-            with open(rx_path) as f:
-                rx = int(f.read())
-            with open(tx_path) as f:
-                tx = int(f.read())
-        except Exception as e:
-            raise RuntimeError(f"Failed to read NIC bytes: {str(e)}")
-        return rx, tx
+            with open(path) as f:
+                return int(f.read().strip())
+        except (FileNotFoundError, ValueError, OSError):
+            return 0
 
+    def _read_counters(self) -> Dict[str, int]:
+        return {f: self._read_stat(f) for f in self._COUNTER_FIELDS}
+
+    @staticmethod
+    def _rx_hw_overflow(counters: Dict[str, int]) -> int:
+        """Combined rx hardware-overflow counter: FIFO overflow + NIC-had-no-host-buffer
+        drops. Summed because the same "NIC couldn't hand the packet to the host in time"
+        failure lands in different fields across drivers (fifo vs missed vs over)."""
+        return (counters["rx_fifo_errors"]
+                + counters["rx_missed_errors"]
+                + counters["rx_over_errors"])
+
+    @staticmethod
+    def _ema_step(prev: Optional[float], instant: float, alpha: float, dt: float) -> float:
+        """dt-aware EMA: ``alpha`` is the per-1s factor, converted to the actual gap so an
+        irregular cadence gives a consistent time constant. Seeds with the first value."""
+        if prev is None:
+            return instant
+        alpha_eff = 1.0 - (1.0 - _clamp01(alpha)) ** dt
+        return alpha_eff * instant + (1.0 - alpha_eff) * prev
+
+    # --- sampling ----------------------------------------------------------------
     def _update_pressure(self):
+        """Sample counters once, update EMA/histories/distress, recompute per-direction
+        scores. Returns ``(rx_score, tx_score)`` -- ``(None, None)`` on the seeding call."""
         now = time.time()
-        rx, tx = self._get_net_bytes()
-        if self._last_rx is None or self._last_tx is None:
-            self._last_rx = rx
-            self._last_tx = tx
+        counters = self._read_counters()
+        softnet = _read_softnet_stats()
+
+        if self._last_time is None:
+            self._last_counters = counters
+            self._last_softnet = softnet
             self._last_time = now
+            self._rx_drop_history.add(counters["rx_packets"], counters["rx_dropped"], self._rx_hw_overflow(counters))
+            self._tx_drop_history.add(counters["tx_packets"], counters["tx_dropped"], counters["tx_fifo_errors"])
+            self._softnet_history.add(softnet["processed"], softnet["squeezed"], softnet["dropped"])
             return None, None
-        delta_rx = rx - self._last_rx
-        delta_tx = tx - self._last_tx
-        delta_time = now - self._last_time
-        if delta_time <= 0:
-            rx_pressure = 0.0
-            tx_pressure = 0.0
+
+        dt = now - self._last_time
+        if dt <= 0:  # non-monotonic clock or double-sample: keep prior score, don't divide by 0
+            return self._score["rx"], self._score["tx"]
+
+        model = self._model()
+        prev = self._last_counters
+
+        def _delta(key):
+            return max(0, counters[key] - prev[key])  # clamp counter reset/wrap
+
+        # --- utilisation load (EMA-smoothed), per direction ---
+        max_kbit = self.bandwidth_kbit
+        speed_gbps = max_kbit / 1_000_000.0 if max_kbit and max_kbit > 0 else 0.0
+        physical_max_pps = speed_gbps * self._PPS_PER_GBPS
+        cpu_pps = self._cpu_cores * model["cpu_pps_per_core"]
+        eff_max_pps = min(physical_max_pps, cpu_pps) if physical_max_pps > 0 else cpu_pps
+
+        for d in ("rx", "tx"):
+            if max_kbit and max_kbit > 0:
+                rate_kbit = _delta(f"{d}_bytes") * 8 / 1000.0 / dt
+                bw_util = _clamp01(rate_kbit / max_kbit)
+            else:
+                if not self._speed_warned:
+                    logger.warning("NIC %s has no known bandwidth; scoring pps/congestion only",
+                                   self.interface)
+                    self._speed_warned = True
+                bw_util = 0.0
+            pps_util = _clamp01((_delta(f"{d}_packets") / dt) / eff_max_pps) if eff_max_pps > 0 else 0.0
+            self._ema_bw[d] = self._ema_step(self._ema_bw[d], bw_util, model["ema_alpha"], dt)
+            self._ema_pps[d] = self._ema_step(self._ema_pps[d], pps_util, model["ema_alpha"], dt)
+
+        # --- append current cumulative counters, then read window-diff ratios ---
+        self._rx_drop_history.add(counters["rx_packets"], counters["rx_dropped"], self._rx_hw_overflow(counters))
+        self._tx_drop_history.add(counters["tx_packets"], counters["tx_dropped"], counters["tx_fifo_errors"])
+        self._softnet_history.add(softnet["processed"], softnet["squeezed"], softnet["dropped"])
+
+        drop_half = max(1e-12, model["drop_half"])
+        rx_drop_half = self._RX_DROP_HALF
+        fifo_half = max(1e-12, model["fifo_half"])
+        softnet_half = max(1e-12, model["softnet_half"])
+
+        # softnet_stat is system-wide, so attribute it to THIS interface by its share of
+        # system rx packets -- otherwise a busy *other* NIC would inflate this NIC's rx
+        # distress. Single-NIC boxes get share ~1; a counter reset falls back to no scaling.
+        last_softnet = self._last_softnet or softnet  # None only if seeding was skipped
+        softnet_processed_delta = softnet["processed"] - last_softnet["processed"]
+        if softnet_processed_delta > 0:
+            softnet_share = _clamp01(_delta("rx_packets") / softnet_processed_delta)
         else:
-            rx_rate_kbit = delta_rx * 8 / 1000 / delta_time
-            tx_rate_kbit = delta_tx * 8 / 1000 / delta_time
-            rx_pressure = rx_rate_kbit / self.bandwidth_kbit
-            tx_pressure = tx_rate_kbit / self.bandwidth_kbit
-            rx_pressure = max(0.0, min(rx_pressure, 1.0))
-            tx_pressure = max(0.0, min(tx_pressure, 1.0))
-        self._last_rx = rx
-        self._last_tx = tx
+            softnet_share = 1.0
+
+        # Activity gate: scale each direction's distress by min(1, pps/min_pps_activity) so a
+        # near-idle direction cannot false-trip on a tiny-denominator ratio.
+        min_pps_activity = max(1e-9, model["min_pps_activity"])
+        rx_act = _clamp01((_delta("rx_packets") / dt) / min_pps_activity)
+        tx_act = _clamp01((_delta("tx_packets") / dt) / min_pps_activity)
+
+        # Raw (pre-saturation, pre-gate) ratios, surfaced for UI diagnostics.
+        # rx drop/hw_overflow tuple indices: (ts=0, packets=1, dropped=2, hw_overflow=3).
+        rx_drop_ratio = self._rx_drop_history.diff_rate(2, 1)
+        rx_hw_ratio = self._rx_drop_history.diff_rate(3, 1)
+        # softnet tuple indices: (ts=0, processed=1, squeezed=2, dropped=3) -- rx only.
+        rx_softnet_squeeze_ratio = self._softnet_history.diff_rate(2, 1)
+        rx_softnet_drop_ratio = self._softnet_history.diff_rate(3, 1)
+        tx_drop_ratio = self._tx_drop_history.diff_rate(2, 1)
+        tx_fifo_ratio = self._tx_drop_history.diff_rate(3, 1)
+        rx_pps = max(0.0, _delta("rx_packets") / dt)
+        tx_pps = max(0.0, _delta("tx_packets") / dt)
+
+        # Named per-source components (so callers see *why* distress is high), each scaled by
+        # the direction's activity gate; softnet also by this NIC's packet share.
+        rx_c_drop = rx_act * model["rx_drop_weight"] * _sat(rx_drop_ratio, rx_drop_half)
+        rx_c_hw = rx_act * _sat(rx_hw_ratio, fifo_half)
+        rx_softnet_squeeze_sat = _sat(rx_softnet_squeeze_ratio, softnet_half)
+        rx_softnet_drop_sat = _sat(rx_softnet_drop_ratio, softnet_half)
+        rx_c_squeeze = (
+            rx_act * softnet_share * self._SOFTNET_SQUEEZE_WEIGHT * rx_softnet_squeeze_sat
+        )
+        rx_c_softnet_drop = rx_act * softnet_share * rx_softnet_drop_sat
+        rx_distress_instant = _noisy_or(rx_c_drop, rx_c_hw, rx_c_squeeze, rx_c_softnet_drop)
+        # Ungated softirq-commons harm (no rx activity/share scaling): a TX small-packet flood
+        # burning the receive softirq raises this while leaving rx/tx collective harm ~0, so it
+        # is the only signal that catches that failure mode. Feeds the controller's TX pps gate.
+        softirq_harm = _noisy_or(rx_softnet_squeeze_sat, rx_softnet_drop_sat)
+
+        tx_c_drop = tx_act * _sat(tx_drop_ratio, drop_half)
+        tx_c_fifo = tx_act * _sat(tx_fifo_ratio, fifo_half)
+        tx_distress_instant = _noisy_or(tx_c_drop, tx_c_fifo)
+
+        # collective_harm = the hardware/softirq classes only (not plain software drops): the
+        # signal that a flood is starving the commons, which the controller's pps gate keys on
+        # (docs §21). raw *_ratio fields are the pre-saturation loss rates for the UI.
+        self._distress_components = {
+            "rx_drop": rx_c_drop, "rx_hw": rx_c_hw,
+            "rx_softnet_squeeze": rx_c_squeeze, "rx_softnet_drop": rx_c_softnet_drop,
+            "tx_drop": tx_c_drop, "tx_fifo": tx_c_fifo,
+            "rx_collective_harm": _noisy_or(rx_c_hw, rx_c_squeeze, rx_c_softnet_drop),
+            "tx_collective_harm": tx_c_fifo,
+            # Software rx_dropped is visible pressure, but does not by itself prove
+            # that receive capacity is exhausted or that ingress shaping can help.
+            # Reserve RX critical for the direct capacity-exhaustion counters.
+            "rx_capacity_exhausted": (
+                rx_hw_ratio >= fifo_half
+                or rx_softnet_drop_ratio >= softnet_half
+            ),
+            "softirq_harm": softirq_harm,
+            "rx_drop_ratio": rx_drop_ratio, "rx_hw_ratio": rx_hw_ratio,
+            "rx_softnet_squeeze_ratio": rx_softnet_squeeze_ratio,
+            "rx_softnet_drop_ratio": rx_softnet_drop_ratio,
+            "tx_drop_ratio": tx_drop_ratio, "tx_fifo_ratio": tx_fifo_ratio,
+            "rx_pps": rx_pps, "tx_pps": tx_pps,
+        }
+
+        # --- capacitor: decaying-max hold so distress cools smoothly ---
+        decay = _clamp01(model["decay_rate"])
+        for d, instant in (("rx", rx_distress_instant), ("tx", tx_distress_instant)):
+            decayed = self._distress[d] * (decay ** dt)
+            self._distress[d] = max(decayed, instant)
+
+        # --- fuse load + distress (distress is primary; utilisation only via the gate) ---
+        util_half = model["util_sat_half"]
+        util_k = model["util_sat_k"]
+        for d in ("rx", "tx"):
+            base_load = max(self._ema_bw[d] or 0.0, self._ema_pps[d] or 0.0)
+            util_sat = _sigmoid(base_load, util_half, util_k)
+            self._score[d] = round(_noisy_or(util_sat, self._distress[d]), 6)
+
+        self._last_counters = counters
+        self._last_softnet = softnet
         self._last_time = now
-        self._pressure_history_rx.append((now, rx_pressure))
-        self._pressure_history_tx.append((now, tx_pressure))
-        self._clean_old_data()
-        return rx_pressure, tx_pressure
+        return self._score["rx"], self._score["tx"]
+
     def _init_tc_stats_history(self, window_sec=None):
-            """
-            Initialise or reset the tc-class-stats sliding window cache (per direction: ingress/egress).
-            """
-            self._tc_stats_history_ingress = {}  # {classid: WindowDiffHistory}
-            self._tc_stats_history_egress = {}   # {classid: WindowDiffHistory}
-            self._tc_stats_window_sec = window_sec or self._WINDOW_SEC
+        """Initialise/reset the per-direction tc-class-stats sliding window cache."""
+        self._tc_stats_history_ingress = {}  # {classid: WindowDiffHistory}
+        self._tc_stats_history_egress = {}   # {classid: WindowDiffHistory}
+        self._tc_stats_window_sec = window_sec or self._WINDOW_SEC
 
     def _update_tc_stats_history(self, usage, direction):
-        """
-        Update the sliding window history for each classid.
-        direction: "ingress" or "egress"
-        """
+        """Update the sliding-window history for each classid (direction: ingress|egress)."""
         if not hasattr(self, '_tc_stats_history_ingress') or not hasattr(self, '_tc_stats_history_egress'):
             self._init_tc_stats_history()
         history = self._tc_stats_history_ingress if direction == "ingress" else self._tc_stats_history_egress
@@ -121,9 +433,7 @@ class NetworkMonitor:
             history[classid].add(value)
 
     def get_tc_class_stats_rate_ingress(self) -> Dict[str, float]:
-        """
-        Return the window-average rate (bytes/sec) for all ingress classids.
-        """
+        """Window-average rate (kbit/s) for every ingress classid."""
         rates = {}
         if not hasattr(self, '_tc_stats_history_ingress'):
             return rates
@@ -139,9 +449,7 @@ class NetworkMonitor:
         return rates
 
     def get_tc_class_stats_rate_egress(self) -> Dict[str, float]:
-        """
-        Return the window-average rate (bytes/sec) for all egress classids.
-        """
+        """Window-average rate (kbit/s) for every egress classid."""
         rates = {}
         if not hasattr(self, '_tc_stats_history_egress'):
             return rates
@@ -157,11 +465,8 @@ class NetworkMonitor:
         return rates
 
     def get_tc_class_stats(self, dev: str, qdisc_handle: int, classids: list, direction: str = None) -> Dict[str, int]:
-        """
-        Read tx/rx byte counts for all classes under the specified device and qdisc handle,
-        then update the sliding window.
-        direction: "ingress" or "egress" (required)
-        """
+        """Read cumulative byte counts for each class under (dev, qdisc_handle) and feed the
+        sliding window. ``direction`` ("ingress"|"egress") selects which window to update."""
         result = subprocess.run(
             ["tc", "-s", "class", "show", "dev", dev, "parent", f"{qdisc_handle}:"],
             capture_output=True,
@@ -178,37 +483,56 @@ class NetworkMonitor:
             self._update_tc_stats_history(usage, direction)
         return usage
 
-
-    def _clean_old_data(self):
-        cutoff = time.time() - self._WINDOW_SEC
-        self._pressure_history_rx = [
-            (t, p) for t, p in self._pressure_history_rx if t >= cutoff
-        ]
-        self._pressure_history_tx = [
-            (t, p) for t, p in self._pressure_history_tx if t >= cutoff
-        ]
-        if not self._pressure_history_rx and self._last_rx is not None:
-            self._pressure_history_rx.append((cutoff + 0.1, 0.0))
-        if not self._pressure_history_tx and self._last_tx is not None:
-            self._pressure_history_tx.append((cutoff + 0.1, 0.0))
-
-    def _get_window_average(self):
-        history_rx = self._pressure_history_rx
-        history_tx = self._pressure_history_tx
-        rx_avg = sum(p for _, p in history_rx) / len(history_rx) if history_rx else 0.0
-        tx_avg = sum(p for _, p in history_tx) / len(history_tx) if history_tx else 0.0
-        return rx_avg, tx_avg
-
     def sample_network_pressure(self):
-        """
-        Sample current NIC pressure once and update history without aggregating.
-        """
+        """Sample NIC pressure once and update EMA/history/distress state."""
         self._update_pressure()
+
+    def get_congestion_pressure(self) -> Dict[str, float]:
+        """Current per-direction congestion *distress* (drops/fifo/softnet), [0, 1].
+        Exposed separately from utilisation for diagnostics/logging."""
+        return {"rx": round(self._distress["rx"], 6), "tx": round(self._distress["tx"], 6)}
 
     def get_current_pressure(self) -> Dict[str, float]:
         """
-        Public API: return the current rolling-window average network pressure without triggering a new sample.
-        Returns: {'rx': 0.xx, 'tx': 0.xx}
+        Public API: return the current per-direction network pressure score without
+        triggering a new sample. ``rx``/``tx`` are the fused [0, 1] scores (contract kept);
+        the extra keys are diagnostics and safe to ignore.
         """
-        rx_avg, tx_avg = self._get_window_average()
-        return {'rx': rx_avg, 'tx': tx_avg}
+        c = self._distress_components
+        return {
+            "rx": self._score["rx"],
+            "tx": self._score["tx"],
+            "rx_util": round(max(self._ema_bw["rx"] or 0.0, self._ema_pps["rx"] or 0.0), 6),
+            "tx_util": round(max(self._ema_bw["tx"] or 0.0, self._ema_pps["tx"] or 0.0), 6),
+            "rx_distress": round(self._distress["rx"], 6),
+            "tx_distress": round(self._distress["tx"], 6),
+            # Instant distress breakdown + collective-harm rollups (docs §21). The rollups
+            # are what the controller's pps gate reads to tell a flood (hardware/softirq
+            # drops) apart from plain byte saturation.
+            "rx_distress_drop": round(c["rx_drop"], 6),
+            "rx_distress_hw": round(c["rx_hw"], 6),
+            "rx_distress_softnet_squeeze": round(c["rx_softnet_squeeze"], 6),
+            "rx_distress_softnet_drop": round(c["rx_softnet_drop"], 6),
+            "tx_distress_drop": round(c["tx_drop"], 6),
+            "tx_distress_fifo": round(c["tx_fifo"], 6),
+            "rx_collective_harm": round(c["rx_collective_harm"], 6),
+            "tx_collective_harm": round(c["tx_collective_harm"], 6),
+            # True only when this host's RX hardware/ring or softnet backlog
+            # actually dropped traffic. Softnet squeeze and generic rx_dropped
+            # remain observable pressure signals, not proof that RX is unavailable.
+            "rx_capacity_exhausted": bool(c["rx_capacity_exhausted"]),
+            # System-wide receive-softirq harm, ungated by this NIC's rx activity/share --
+            # the "commons" signal the controller's TX pps gate uses to catch an egress
+            # small-packet flood that never lifts tx_pressure.
+            "softirq_harm": round(c["softirq_harm"], 6),
+            # Raw pre-saturation loss ratios (Δevent / Δpackets or Δprocessed), so the UI can
+            # show the actual drop/overflow/softnet rate behind a distress reading.
+            "rx_drop_ratio": round(c["rx_drop_ratio"], 8),
+            "rx_hw_ratio": round(c["rx_hw_ratio"], 8),
+            "rx_softnet_squeeze_ratio": round(c["rx_softnet_squeeze_ratio"], 8),
+            "rx_softnet_drop_ratio": round(c["rx_softnet_drop_ratio"], 8),
+            "tx_drop_ratio": round(c["tx_drop_ratio"], 8),
+            "tx_fifo_ratio": round(c["tx_fifo_ratio"], 8),
+            "rx_pps": round(c["rx_pps"], 2),
+            "tx_pps": round(c["tx_pps"], 2),
+        }

--- a/monitor/network_pressure.py
+++ b/monitor/network_pressure.py
@@ -1,0 +1,356 @@
+# Copyright (c) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Network-pressure publishing + UI aggregation.
+
+The scoring model lives in :mod:`monitor.network` (``NetworkMonitor``): sampling, EMA,
+utilisation/congestion modelling, and the fused per-direction [0, 1] score. This module is
+the layer *above* that: it takes the fused scores the control loop already computed and
+
+  * publishes an immutable cross-thread snapshot (``publish_network_pressure_snapshot`` /
+    ``_get_network_pressure_snapshot``) so the dashboard reads the exact values used for
+    shaping instead of standing up a second monitor that would diverge on EMA/counter
+    windows, and
+  * transforms that snapshot into UI DTOs -- percent-scaled fields, LOW/MEDIUM/HIGH/CRITICAL
+    display levels, plain-language ``reason`` text, and the System Overview gauge rollup.
+
+Nothing here samples the NIC or holds live monitor state; it depends only on ``b_config``
+thresholds. Kept separate from the model so the "how do we score" and "how do we present"
+concerns evolve independently.
+"""
+
+import os
+import threading
+import time
+from typing import Any, Dict, Optional
+
+from config.config import b_config
+from monitor.network import NetworkMonitor
+from utils.logger import logger
+
+
+# --- pressure snapshot: shared buffer + UI aggregation --------------------------
+# The controller owns the live NetworkMonitor state; the dashboard must not create a
+# second monitor (it would diverge on EMA/counter windows). Instead the controller
+# publishes its fused scores here and the dashboard reads an immutable copy.
+
+_NETWORK_PRESSURE_SNAPSHOT_LOCK = threading.Lock()
+_NETWORK_PRESSURE_SNAPSHOT: Dict[str, Dict[str, float]] = {}
+
+# Background sampler used by monitor-only mode so network pressure stays available even
+# without the balancer/controller network loop.
+_NETWORK_PRESSURE_REFRESH_INTERVAL_SEC: float = 1.0
+_network_pressure_refresh_started = False
+_network_pressure_refresh_lock = threading.Lock()
+_network_pressure_stop_event = threading.Event()
+_network_pressure_collector_thread = None
+
+# get_current_pressure() diagnostic fields kept alongside the fused rx/tx score so a UI
+# card can show *why* a direction is under pressure (0..1 fractions / raw ratios).
+_NETWORK_PRESSURE_DIAG_KEYS = (
+    "rx_util", "tx_util", "rx_distress", "tx_distress",
+    "rx_collective_harm", "tx_collective_harm",
+    "rx_capacity_exhausted",
+    "rx_distress_drop", "rx_distress_hw",
+    "rx_distress_softnet_squeeze", "rx_distress_softnet_drop",
+    "tx_distress_drop", "tx_distress_fifo",
+    "rx_drop_ratio", "rx_hw_ratio",
+    "rx_softnet_squeeze_ratio", "rx_softnet_drop_ratio",
+    "tx_drop_ratio", "tx_fifo_ratio",
+    "rx_pps", "tx_pps",
+)
+
+
+def publish_network_pressure_snapshot(interfaces: Dict[str, Dict[str, Any]]) -> None:
+    """Publish the control loop's latest fused score for every monitored NIC, so the
+    dashboard reads the exact values used for shaping instead of re-sampling."""
+    snapshot: Dict[str, Dict[str, float]] = {}
+    for name, pressure in interfaces.items():
+        if not isinstance(pressure, dict):
+            continue
+        try:
+            rx = min(1.0, max(0.0, float(pressure.get("rx", 0.0))))
+            tx = min(1.0, max(0.0, float(pressure.get("tx", 0.0))))
+        except (TypeError, ValueError):
+            continue
+        entry: Dict[str, float] = {"rx": rx, "tx": tx}
+        for key in _NETWORK_PRESSURE_DIAG_KEYS:
+            value = pressure.get(key)
+            if key == "rx_capacity_exhausted" and isinstance(value, bool):
+                entry[key] = value
+            elif isinstance(value, (int, float)) and not isinstance(value, bool):
+                entry[key] = float(value)
+        snapshot[str(name)] = entry
+    with _NETWORK_PRESSURE_SNAPSHOT_LOCK:
+        _NETWORK_PRESSURE_SNAPSHOT.clear()
+        _NETWORK_PRESSURE_SNAPSHOT.update(snapshot)
+
+
+def _get_network_pressure_snapshot() -> Dict[str, Dict[str, float]]:
+    with _NETWORK_PRESSURE_SNAPSHOT_LOCK:
+        return {name: dict(pressure) for name, pressure in _NETWORK_PRESSURE_SNAPSHOT.items()}
+
+
+def _is_network_interface_candidate(name: str) -> bool:
+    lower = (name or "").lower()
+    if not lower or lower == "lo":
+        return False
+    if lower.startswith("docker") or lower.startswith("veth"):
+        return False
+    if lower.startswith("br-") or lower.startswith("virbr") or lower.startswith("lxc"):
+        return False
+    return True
+
+
+def _detect_link_speed_kbit(iface: str) -> int:
+    try:
+        with open(f"/sys/class/net/{iface}/speed") as f:
+            mbit = int(f.read().strip())
+        if mbit > 0:
+            return mbit * 1000
+    except (OSError, ValueError):
+        pass
+    return 0
+
+
+def _build_network_monitors() -> Dict[str, NetworkMonitor]:
+    base = "/sys/class/net"
+    monitors: Dict[str, NetworkMonitor] = {}
+    try:
+        names = sorted(os.listdir(base))
+    except OSError:
+        return monitors
+
+    for iface in names:
+        if not _is_network_interface_candidate(iface):
+            continue
+        iface_path = os.path.join(base, iface)
+        if not os.path.exists(iface_path):
+            continue
+        # Bond/team/bridge slaves should be attributed to their master interface.
+        if os.path.islink(os.path.join(iface_path, "master")):
+            continue
+        bw = _detect_link_speed_kbit(iface)
+        monitors[iface] = NetworkMonitor(iface, bw)
+    return monitors
+
+
+def _network_pressure_collector_loop() -> None:
+    monitors = _build_network_monitors()
+    while not _network_pressure_stop_event.is_set():
+        loop_start = time.time()
+        try:
+            if not monitors:
+                monitors = _build_network_monitors()
+
+            snapshot: Dict[str, Dict[str, Any]] = {}
+            stale_ifaces = []
+            for iface, monitor in monitors.items():
+                if not os.path.exists(f"/sys/class/net/{iface}"):
+                    stale_ifaces.append(iface)
+                    continue
+                try:
+                    monitor.sample_network_pressure()
+                    snapshot[iface] = monitor.get_current_pressure()
+                except Exception as exc:
+                    logger.debug("Network pressure sampling failed for '%s': %s", iface, exc)
+
+            for iface in stale_ifaces:
+                monitors.pop(iface, None)
+
+            publish_network_pressure_snapshot(snapshot)
+        except Exception as exc:
+            logger.debug("network pressure collector error: %s", exc)
+
+        elapsed = time.time() - loop_start
+        _network_pressure_stop_event.wait(
+            max(0.1, _NETWORK_PRESSURE_REFRESH_INTERVAL_SEC - elapsed)
+        )
+
+
+def start_network_pressure_collector() -> None:
+    """Start monitor-side network pressure sampling (idempotent)."""
+    global _network_pressure_refresh_started, _network_pressure_collector_thread
+    with _network_pressure_refresh_lock:
+        if _network_pressure_refresh_started:
+            return
+        _network_pressure_refresh_started = True
+        _network_pressure_stop_event.clear()
+        _network_pressure_collector_thread = threading.Thread(
+            target=_network_pressure_collector_loop,
+            daemon=True,
+            name="network-pressure-collector",
+        )
+        _network_pressure_collector_thread.start()
+
+
+def stop_network_pressure_collector() -> None:
+    """Stop monitor-side network pressure sampling thread if running."""
+    global _network_pressure_refresh_started
+    with _network_pressure_refresh_lock:
+        if not _network_pressure_refresh_started:
+            return
+        _network_pressure_refresh_started = False
+    _network_pressure_stop_event.set()
+    if _network_pressure_collector_thread is not None:
+        _network_pressure_collector_thread.join(timeout=2)
+
+
+def _network_pressure_level(score: float, critical_eligible: bool = True) -> str:
+    thresholds = getattr(b_config, "network_thresholds", None) or {}
+    if critical_eligible and score >= thresholds.get("critical", 0.9):
+        return "CRITICAL"
+    if score >= thresholds.get("high", 0.7):
+        return "HIGH"
+    if score >= thresholds.get("medium", 0.5):
+        return "MEDIUM"
+    return "LOW"
+
+
+def _compute_fused_network_pressure(interfaces: Dict[str, Dict[str, float]]) -> Dict[str, Any]:
+    """Aggregate per-NIC fused pressure for the System Overview gauge.
+
+    Severity is the worst NIC/direction (never diluted by idle NICs); breadth is the
+    NICs whose fused score reached the configured medium band.
+    """
+    if not interfaces:
+        return {
+            "busy_nics": [], "total_nics": 0, "busy_ratio": None,
+            "busy_pct": None, "level": "NO DATA", "pressure_pct": None,
+            "worst_nic": None, "worst_direction": None,
+        }
+
+    medium = (getattr(b_config, "network_thresholds", None) or {}).get("medium", 0.5)
+    per_nic = []
+    for name, pressure in interfaces.items():
+        rx = pressure["rx"]
+        tx = pressure["tx"]
+        rx_score = rx
+        critical = (getattr(b_config, "network_thresholds", None) or {}).get("critical", 0.9)
+        if not pressure.get("rx_capacity_exhausted", False):
+            rx_score = min(rx_score, max(0.0, float(critical) - 0.000001))
+        score = max(rx_score, tx)
+        direction = "RX" if rx_score > tx else "TX"
+        per_nic.append((score, name, direction))
+
+    per_nic.sort(key=lambda item: (-item[0], item[1], item[2]))
+    worst_score, worst_nic, worst_direction = per_nic[0]
+    busy_nics = [name for score, name, _ in per_nic if score >= medium]
+    total_nics = len(per_nic)
+    busy_ratio = len(busy_nics) / total_nics
+
+    return {
+        "busy_nics": busy_nics,
+        "total_nics": total_nics,
+        "busy_ratio": round(busy_ratio, 4),
+        "busy_pct": round(busy_ratio * 100.0, 2),
+        "level": _network_pressure_level(worst_score),
+        "pressure_pct": round(worst_score * 100.0, 2),
+        "worst_nic": worst_nic,
+        "worst_direction": worst_direction,
+    }
+
+
+def _network_pressure_reason(direction: str, score: float, diag: Dict[str, float]) -> Optional[str]:
+    """Short, user-facing explanation of why a direction reached high/critical (``None``
+    below the ``high`` band): the dominant driver in plain language plus the raw rate."""
+    thresholds = getattr(b_config, "network_thresholds", None) or {}
+    if score < thresholds.get("high", 0.7):
+        return None
+
+    util = float(diag.get(f"{direction}_util", 0.0) or 0.0)
+    distress = float(diag.get(f"{direction}_distress", 0.0) or 0.0)
+
+    # Utilisation-driven: link genuinely near line rate, little/no loss.
+    if util >= 0.90 and distress < 0.5:
+        return f"near max bandwidth ({util * 100:.0f}% used)"
+
+    # Congestion-driven: name the worst per-source distress component.
+    if direction == "rx":
+        candidates = [
+            (diag.get("rx_distress_drop", 0.0), "packet loss", diag.get("rx_drop_ratio", 0.0)),
+            (diag.get("rx_distress_hw", 0.0), "receive buffer overflow", diag.get("rx_hw_ratio", 0.0)),
+            (diag.get("rx_distress_softnet_squeeze", 0.0), "system overloaded",
+             diag.get("rx_softnet_squeeze_ratio", 0.0)),
+            (diag.get("rx_distress_softnet_drop", 0.0), "system overloaded",
+             diag.get("rx_softnet_drop_ratio", 0.0)),
+        ]
+    else:
+        candidates = [
+            (diag.get("tx_distress_drop", 0.0), "packet loss", diag.get("tx_drop_ratio", 0.0)),
+            (diag.get("tx_distress_fifo", 0.0), "send buffer overflow", diag.get("tx_fifo_ratio", 0.0)),
+        ]
+
+    worst_component, label, ratio = max(candidates, key=lambda item: float(item[0] or 0.0))
+    if float(worst_component or 0.0) <= 0.0:
+        # Saturated but no identifiable component: fall back to util.
+        return f"near max bandwidth ({util * 100:.0f}% used)"
+    ratio = float(ratio or 0.0)
+    if ratio > 0.0:
+        # UI copy should never show impossible percentages, even if kernel counters are noisy.
+        ratio_pct = max(0.0, min(ratio * 100.0, 100.0))
+        return f"{label} {ratio_pct:.2f}%"
+    return label
+
+
+def _build_network_interface_pressure(interfaces: Dict[str, Dict[str, float]]) -> Dict[str, Any]:
+    """Per-NIC, per-direction diagnostics for the Network card: a
+    ``{nic: {rx: {...}, tx: {...}}}`` map of percent-scaled fields plus a per-direction
+    ``level`` and ``reason``."""
+    result: Dict[str, Any] = {}
+    for name, diag in interfaces.items():
+        if not isinstance(diag, dict):
+            continue
+
+        def _pct(key: str) -> float:
+            value = diag.get(key, 0.0)
+            if not isinstance(value, (int, float)) or isinstance(value, bool):
+                return 0.0
+            # Clamp to [0, 100]% so a counter anomaly cannot show an impossible ratio.
+            return round(min(1.0, max(0.0, float(value))) * 100.0, 4)
+
+        def _loss_pct(key: str, pps_key: str) -> Optional[float]:
+            pps = diag.get(pps_key)
+            raw_ratio = diag.get(key)
+            if isinstance(raw_ratio, (int, float)) and not isinstance(raw_ratio, bool) and float(raw_ratio) <= 0:
+                return 0.0
+            if pps is None:
+                # Older snapshots predate the activity metadata; keep their stored value.
+                return _pct(key)
+            model = getattr(b_config, "network_pressure_model", None) or {}
+            min_pps = model.get("min_pps_activity", 2000.0)
+            if not isinstance(pps, (int, float)) or isinstance(pps, bool) or float(pps) < float(min_pps):
+                # Low packet-rate windows are too noisy for meaningful loss ratio semantics.
+                # For display, keep this deterministic as "no observable loss" instead of N/A.
+                return 0.0
+            return _pct(key)
+
+        rx_score = float(diag.get("rx", 0.0) or 0.0)
+        tx_score = float(diag.get("tx", 0.0) or 0.0)
+        result[str(name)] = {
+            "rx": {
+                "util_pct": _pct("rx_util"),
+                "distress_pct": _pct("rx_distress"),
+                "score_pct": round(rx_score * 100.0, 2),
+                "drop_ratio_pct": _loss_pct("rx_drop_ratio", "rx_pps"),
+                "hw_overflow_ratio_pct": _pct("rx_hw_ratio"),
+                "softnet_squeeze_ratio_pct": _pct("rx_softnet_squeeze_ratio"),
+                "softnet_drop_ratio_pct": _pct("rx_softnet_drop_ratio"),
+                "collective_harm_pct": _pct("rx_collective_harm"),
+                "level": _network_pressure_level(
+                    rx_score, critical_eligible=bool(diag.get("rx_capacity_exhausted", False))
+                ),
+                "reason": _network_pressure_reason("rx", rx_score, diag),
+            },
+            "tx": {
+                "util_pct": _pct("tx_util"),
+                "distress_pct": _pct("tx_distress"),
+                "score_pct": round(tx_score * 100.0, 2),
+                "drop_ratio_pct": _loss_pct("tx_drop_ratio", "tx_pps"),
+                "fifo_ratio_pct": _pct("tx_fifo_ratio"),
+                "collective_harm_pct": _pct("tx_collective_harm"),
+                "level": _network_pressure_level(tx_score),
+                "reason": _network_pressure_reason("tx", tx_score, diag),
+            },
+        }
+    return result

--- a/monitor/system_info.py
+++ b/monitor/system_info.py
@@ -60,6 +60,11 @@ from monitor.metrics.history import (
     persist_dynamic_snapshot_if_due,
 )
 from monitor.disk_pressure import compute_disk_pressure
+from monitor.network_pressure import (
+    _get_network_pressure_snapshot,
+    _compute_fused_network_pressure,
+    _build_network_interface_pressure,
+)
 from utils.logger import logger
 
 _STATIC_CACHE: Dict[str, Any] = {"data": None, "ts": 0.0}
@@ -336,64 +341,6 @@ def _get_network_runtime_bw() -> Dict[str, Any]:
     }
 
 
-_NETWORK_BUSY_THRESHOLD_PCT = 80  # NIC is "busy" when max(rxUtil, txUtil) >= 80%
-
-
-def _compute_network_pressure(network_bw: Dict[str, Any], net_static: Dict[str, Any]) -> Dict[str, Any]:
-    """Compute per-NIC busy ratio based on actual link speed.
-
-    Returns a dict with busy_nics, total_nics, busy_ratio, busy_pct, busy_level
-    matching the disk IO pressure pattern.
-    """
-    interfaces = network_bw.get("interfaces") or {}
-    valid_nics = net_static.get("valid_nics") or []
-    nic_speeds = {nic["name"]: nic["speed_mbps"] for nic in valid_nics if isinstance(nic, dict) and nic.get("speed_mbps", 0) > 0}
-
-    busy_nics: List[str] = []
-    total_nics = 0
-
-    for nic_name, speed_mbps in nic_speeds.items():
-        nic_data = interfaces.get(nic_name)
-        if not isinstance(nic_data, dict):
-            continue
-        total_nics += 1
-        rx_bytes = nic_data.get("rx_bytes_per_sec", 0.0)
-        tx_bytes = nic_data.get("tx_bytes_per_sec", 0.0)
-        rx_mbps = rx_bytes * 8.0 / 1_000_000.0
-        tx_mbps = tx_bytes * 8.0 / 1_000_000.0
-        rx_util = min(rx_mbps / speed_mbps * 100.0, 100.0) if speed_mbps > 0 else 0.0
-        tx_util = min(tx_mbps / speed_mbps * 100.0, 100.0) if speed_mbps > 0 else 0.0
-        if max(rx_util, tx_util) >= _NETWORK_BUSY_THRESHOLD_PCT:
-            busy_nics.append(nic_name)
-
-    busy_count = len(busy_nics)
-    busy_ratio = busy_count / total_nics if total_nics > 0 else None
-    busy_pct = busy_ratio * 100.0 if busy_ratio is not None else None
-
-    _nth = b_config.network_thresholds or {}
-    _nth_low = _nth.get("low", 0.4)
-    _nth_medium = _nth.get("medium", 0.6)
-    _nth_high = _nth.get("high", 0.8)
-    if total_nics == 0 or busy_ratio is None:
-        busy_level = "NO DATA"
-    elif busy_ratio < _nth_low:
-        busy_level = "LOW"
-    elif busy_ratio < _nth_medium:
-        busy_level = "MEDIUM"
-    elif busy_ratio < _nth_high:
-        busy_level = "HIGH"
-    else:
-        busy_level = "CRITICAL"
-
-    return {
-        "busy_nics": busy_nics,
-        "total_nics": total_nics,
-        "busy_ratio": round(busy_ratio, 4) if busy_ratio is not None else None,
-        "busy_pct": round(busy_pct, 2) if busy_pct is not None else None,
-        "busy_level": busy_level,
-    }
-
-
 def _is_physical_nic_candidate(name: str) -> bool:
     """True for interfaces that can be a real shaping target.
 
@@ -455,6 +402,12 @@ def _get_network_static_info() -> Dict[str, Any]:
         if lower == "lo" or lower.startswith("docker") or lower.startswith("veth"):
             return False
         if lower.startswith("br-") or lower.startswith("virbr"):
+            return False
+        # Skip enslaved interfaces (bond/team slaves, bridge ports). An enslaved NIC
+        # exposes a /sys/class/net/<if>/master symlink; the *master* (e.g. bond0) is the
+        # one that carries and should shape the traffic. Shaping a slave directly would
+        # double-shape the same physical link and fight the master's qdisc.
+        if os.path.islink(f"/sys/class/net/{name}/master"):
             return False
         return True
 
@@ -715,7 +668,15 @@ class _DynamicInfoCollector:
         return get_memory_dynamic()
 
     def network(self) -> Dict[str, Any]:
-        return self._network_bw_runtime()
+        network = self._network_bw_runtime()
+        # Keep network pressure diagnostics with the network section so a
+        # network-only monitored set still persists loss/congestion history.
+        try:
+            snapshot = _get_network_pressure_snapshot()
+            network['pressure_interfaces'] = _build_network_interface_pressure(snapshot)
+        except Exception as e:
+            logger.debug(f"Network pressure diagnostics unavailable: {e}")
+        return network
 
     def disk(self) -> Dict[str, Any]:
         disk_stats: Dict[str, Any] = {}
@@ -794,18 +755,20 @@ class _DynamicInfoCollector:
         except Exception as e:
             logger.debug(f"PSIMonitor unavailable for raw pressure: {e}")
 
-        # Network pressure: per-NIC busy ratio based on actual link speed.
-        # Reuses the memoized runtime bandwidth so a full snapshot does not
-        # sample the NICs twice for the network and pressure sections.
+        # Network pressure: use the same per-NIC fused scores the controller
+        # sampled for shaping.
         try:
-            network_bw = self._network_bw_runtime()
-            net_static = _get_network_static_info()
-            net_pressure_result = _compute_network_pressure(network_bw, net_static)
+            net_snapshot = _get_network_pressure_snapshot()
+            net_pressure_result = _compute_fused_network_pressure(net_snapshot)
+            pressure_extra['network_interfaces'] = _build_network_interface_pressure(net_snapshot)
             pressure_extra['network_busy_nics'] = net_pressure_result['busy_nics']
             pressure_extra['network_total_nics'] = net_pressure_result['total_nics']
             pressure_extra['network_busy_ratio'] = net_pressure_result['busy_ratio']
             pressure_extra['network_busy_pct'] = net_pressure_result['busy_pct']
-            pressure_extra['network_busy_level'] = net_pressure_result['busy_level']
+            pressure_extra['network_pressure_level'] = net_pressure_result['level']
+            pressure_extra['network_pressure_pct'] = net_pressure_result['pressure_pct']
+            pressure_extra['network_worst_nic'] = net_pressure_result['worst_nic']
+            pressure_extra['network_worst_direction'] = net_pressure_result['worst_direction']
         except Exception as e:
             logger.debug(f"Network pressure calculation unavailable: {e}")
 


### PR DESCRIPTION
- Redesign network pressure evaluation with per-NIC RX/TX scores that combine bandwidth, PPS, packet drops, hardware overflow, and softnet congestion.
- Distinguish busy-but-healthy traffic from real congestion, avoiding pressure actions on clean links while detecting loss and small-packet floods.
- Add optional mitigation for packet-rate pressure, including fq_codel fairness, per-app TX PPS policing, and RX RPS escalation.
- Add configurable network pressure calibration parameters and expose detailed diagnostics through monitor APIs, history metrics, and Dashboard views.
- Update pressure algorithm documentation and adjust the low-priority network bandwidth ceiling to allow 100% when no pressure action is needed