### PR TITLE
Fix the app name and disk pressure issues

### DIFF
--- a/balancer/balancer/balancer.py
+++ b/balancer/balancer/balancer.py
@@ -1088,6 +1088,8 @@ class DynamicBalancer:
             top_cgroups = set()
             if app_info.get('cgroup'):
                 top_cgroups.add(os.path.basename(app_info['cgroup']))
+            if app_info.get('cgroup_id'):
+                top_cgroups.add(app_info['cgroup_id'])
             for extra in app_info.get('extra_cgroups', []) or []:
                 top_cgroups.add(os.path.basename(extra))
 
@@ -1547,7 +1549,11 @@ class DynamicBalancer:
         reason is "system_pressure" even for the io.max part -- there is no separate disk
         level under this policy to attribute it to.
         """
-        app_name = target.get('process', {}).get('name') or ''
+        app_name = (
+            (target.get('app') or {}).get('name')
+            or target.get('process', {}).get('name')
+            or app_id
+        )
         total_mem = self.resource_monitor.get_total_memory()
         logger.info(f"Adjusting resources for app: {app_id}")
         extra_cgroup_ids = target.get('extra_cgroups', [])
@@ -1887,7 +1893,11 @@ class DynamicBalancer:
         *pressure_level* is the level of the channel that triggered this limit; it is
         recorded on the registry entry so the UI can say *why* the app was limited.
         """
-        app_name = target_app.get('process', {}).get('name') or ''
+        app_name = (
+            (target_app.get('app') or {}).get('name')
+            or target_app.get('process', {}).get('name')
+            or app_id
+        )
         total_mem = self.resource_monitor.get_total_memory()
         logger.info(f"Adjusting resources for app: {app_id}")
 
@@ -2111,6 +2121,7 @@ class DynamicBalancer:
             app_id = app_info['app'].get('id') if app_info.get('app') else None
             if not app_id:
                 continue
+            sampled_cgroup = (app_info.get('cgroup_id') or '').strip()
             proc = app_info.get('process', {})
             app_name = (proc.get('name') or '').lower()
             cand_mb = (proc.get('io_read_rate') or 0.0) + (proc.get('io_write_rate') or 0.0)
@@ -2129,9 +2140,12 @@ class DynamicBalancer:
                 continue
             # 1b) Excluded by a user restore. Checked again here because this arm holds
             #     its batch across ticks while the disk sits at "high".
+            candidate_cgroups = list(app_info.get('extra_cgroups') or [])
+            if sampled_cgroup and sampled_cgroup not in candidate_cgroups:
+                candidate_cgroups.append(sampled_cgroup)
             with self.all_limits.lock:  # the REST thread can add/remove entries mid-walk
                 excluded = self.all_limits.is_excluded(
-                    app_id, app_name, app_info.get('extra_cgroups') or [])
+                    app_id, app_name, candidate_cgroups)
             if excluded is not None:
                 logger.info(f"[disk-io] skip {cand}: excluded from auto-limit "
                             f"({excluded.get('key')})")
@@ -2142,7 +2156,7 @@ class DynamicBalancer:
             #    registry entry was keyed by the resolved cgroup. Matching only one of them
             #    would re-cap the same app on every critical tick and never reach the
             #    second-heaviest consumer.
-            known_ids = [i for i in (app_id, (controlled_data or {}).get('app_id')) if i]
+            known_ids = [i for i in (app_id, sampled_cgroup, (controlled_data or {}).get('app_id')) if i]
             existing = next(
                 (e for e in (self.all_limits.by_any_id(i, source="auto") for i in known_ids)
                  if e and e[1].limit_parts.get('io_limited')), None)
@@ -2161,6 +2175,10 @@ class DynamicBalancer:
                 resolved_id = self._resolve_controlled_target(app_info, controlled_data)
                 if resolved_id:
                     app_id = resolved_id
+            elif sampled_cgroup:
+                # Disk-IO throttling writes cgroup io.max. Keep display identity from
+                # process naming, but target the sampled cgroup basename for writes.
+                app_id = sampled_cgroup
 
             rates = self.get_limited_rates(priority or "undefined")
             # On the candidate, not the return tuple: the apply path only needs it to

--- a/balancer/test/test_app_identity.py
+++ b/balancer/test/test_app_identity.py
@@ -300,6 +300,20 @@ class RegisteredAppMatchTests(unittest.TestCase):
              'cgroup': '/system.slice/lo2-io.scope'})
         self.assertEqual(result['id'], 'lo2-io.scope')
 
+    def test_session_scope_fallback_prefers_script_identity_over_interpreter(self):
+        mon = self._monitor([self._app("lo-io.scope", "fio_lo", "/tmp/fio_lo")])
+        result = mon.try_match_app(
+            {
+                'dominant_name': 'python3',
+                'dominant_cmdline': 'python3 /opt/workloads/fio_runner.py --name lo',
+                'names': {'python3'},
+                'exe': '/usr/bin/python3',
+                'cgroup': '/user.slice/session-12.scope',
+            }
+        )
+        self.assertEqual(result['id'], 'fio_runner.py')
+        self.assertEqual(result['name'], 'fio_runner.py')
+
 
 class RepresentativeCgroupTests(unittest.TestCase):
     """Which cgroup an app's matched PIDs are taken to live in.

--- a/balancer/test/test_disk_io_policy.py
+++ b/balancer/test/test_disk_io_policy.py
@@ -257,8 +257,9 @@ class ConfigSurfaceTests(unittest.TestCase):
                     f"{media}.{field}")
 
 
-def _consumer(app_id, mb=500.0, iops=5000.0, name='fio'):
+def _consumer(app_id, mb=500.0, iops=5000.0, name='fio', cgroup_id=''):
     return {'app': {'id': app_id},
+            'cgroup_id': cgroup_id,
             'process': {'name': name, 'io_read_rate': 0.0, 'io_write_rate': mb,
                         'io_read_iops': 0.0, 'io_write_iops': iops}}
 
@@ -329,6 +330,22 @@ class AlreadyLimitedTests(unittest.TestCase):
         b = self._b(_limited('lo-io.scope', 'lo-app', ['lo-io.scope'], io_limited=False))
         app_id, _ = self._select(b, [_consumer('lo-io.scope')])
         self.assertEqual(app_id, 'lo-io.scope')
+
+    def test_uncontrolled_process_identity_uses_sampled_cgroup_as_throttle_key(self):
+        b = self._b()
+        app_id, _ = self._select(
+            b,
+            [_consumer('fio_runner.py', cgroup_id='session-12.scope', name='fio_runner.py')]
+        )
+        self.assertEqual(app_id, 'session-12.scope')
+
+    def test_already_limited_match_checks_sampled_cgroup_identity(self):
+        b = self._b(_limited('session-12.scope', 'session-12.scope', ['session-12.scope']))
+        app_id, _ = self._select(
+            b,
+            [_consumer('fio_runner.py', cgroup_id='session-12.scope', name='fio_runner.py')]
+        )
+        self.assertIsNone(app_id)
 
 
 class PublicIdTests(unittest.TestCase):

--- a/dashboard/src/components/HistoryDashboard.tsx
+++ b/dashboard/src/components/HistoryDashboard.tsx
@@ -553,9 +553,17 @@ function buildPressureTrendPoints(items: HistorySnapshotItem[]): PressureTrendPo
     const systemPressure = isNumber(scoreRaw as number | null)
       ? Math.round((scoreRaw as number) * 100)
       : getPressurePeak(dynamic)
-    // Disk pressure: busy-disk ratio from _compute_disk_pressure (busy_disks/total_disks × 100)
-    const diskBusyPct = (dynamic?.disk as Record<string, unknown> | undefined)?.busy_pct
-    const diskPressure = isNumber(diskBusyPct as number | null) ? (diskBusyPct as number) : null
+    // Disk pressure: match the System Overview gauge — PSI-gated severity
+    // (pressure_pct), falling back to the busy-disk ratio (busy_pct) when the
+    // severity is unavailable (USE-only path with no pressure tick).
+    const diskData = dynamic?.disk as Record<string, unknown> | undefined
+    const diskPressurePctRaw = diskData?.pressure_pct
+    const diskBusyPct = diskData?.busy_pct
+    const diskPressure = isNumber(diskPressurePctRaw as number | null)
+      ? (diskPressurePctRaw as number)
+      : isNumber(diskBusyPct as number | null)
+        ? (diskBusyPct as number)
+        : null
     // Network pressure: worst fused RX/TX score across monitored NICs.
     const netPressurePct = (dynamic?.pressure as Record<string, unknown> | undefined)?.network_pressure_pct
     const networkPressure = isNumber(netPressurePct as number | null) ? (netPressurePct as number) : null

--- a/monitor/metrics/history.py
+++ b/monitor/metrics/history.py
@@ -367,6 +367,10 @@ def _build_dynamic_history_payload(data: Dict[str, Any]) -> Dict[str, Any]:
             "busy_ratio": to_float(disk.get("busy_ratio")),
             "busy_pct": to_float(disk.get("busy_pct")),
             "busy_level": disk.get("busy_level"),
+            # PSI-gated severity (distinct from busy_pct breadth). Persisted so the
+            # history Disk Pressure chart plots the same value the live Disk IO
+            # Pressure gauge shows; without this the chart falls back to busy_pct.
+            "pressure_pct": to_float(disk.get("pressure_pct")),
         }
 
     if "network" in data:

--- a/monitor/res_monitor.py
+++ b/monitor/res_monitor.py
@@ -3,6 +3,7 @@
 
 import os
 import re
+import shlex
 # [SECURITY REVIEW]: All subprocess calls in this module use list-based arguments
 # with shell=False (default). No untrusted shell execution or string
 # concatenation is performed. All inputs are internally validated.
@@ -1129,6 +1130,21 @@ class ResourceMonitor:
                 scope_name,
             ):
                 dominant_name = process_info.get('dominant_name', '')
+                # Prefer the same commandline-aware identity rule used by app discovery:
+                # interpreter launches (python3 foo.py) should surface foo.py, not python3.
+                dominant_cmdline = (process_info.get('dominant_cmdline') or '').strip()
+                if dominant_name and dominant_cmdline:
+                    try:
+                        cmd_tokens = shlex.split(dominant_cmdline)
+                    except ValueError:
+                        cmd_tokens = dominant_cmdline.split()
+                    resolved = derived_process_identity({
+                        'name': dominant_name,
+                        'exe': process_info.get('exe') or '',
+                        'cmdline': cmd_tokens,
+                    }).strip()
+                    if resolved:
+                        dominant_name = resolved
                 if dominant_name:
                     return {
                         'type': 'process',
@@ -1253,6 +1269,9 @@ class ResourceMonitor:
                     'io_per_disk': process.get('io_per_disk', {}),
                 },
                 'app': app_info,
+                # Primary sampled cgroup basename. Disk-IO throttling targets io.max,
+                # which is cgroup-scoped even when app identity/display is process-scoped.
+                'cgroup_id': os.path.basename(process.get('cgroup') or ''),
                 # Full PID list (see get_top_resource_consumers) for close-detection.
                 'pids': list(process['pids']),
                 'extra_cgroups': [


### PR DESCRIPTION
- Directly use the app name instead of python/bash interpreter
- Align the disk pressure for system overview and history