### PR TITLE
Fix the secutiry issue of PTK0009133

### DIFF
--- a/balancer/controller/controller.py
+++ b/balancer/controller/controller.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import pwd
 import subprocess # nosec
 import time
 from subprocess import check_output # nosec
@@ -137,11 +138,11 @@ class Controller:
     def restore_cpu_throttle(self):
         scopes = self.get_user_scopes()
         services = self.get_app_services()
-        cmd_prefix = ['sudo'] if getattr(self.config, "vendor", "") == "generic" else []
 
         logger.debug(f"restore_cpu_throttle scopes = {scopes}, services = {services}")
         for scope in scopes:
-            cmd = [*cmd_prefix, 'systemctl', 'set-property', '--runtime', '%s' % scope, 'CPUQuota=100%']
+            # smartune runs as root; system scopes need no sudo.
+            cmd = ['systemctl', 'set-property', '--runtime', '%s' % scope, 'CPUQuota=100%']
             result = subprocess.run(cmd,
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
 
@@ -153,16 +154,40 @@ class Controller:
     def high_cpu_throttle(self):
         scopes = self.get_user_scopes()
         services = self.get_app_services()
-        cmd_prefix = ['sudo'] if getattr(self.config, "vendor", "") == "generic" else []
 
         logger.debug(f"high_cpu_throttle scopes = {scopes}, services = {services}")
         for scope in scopes:
-            result = subprocess.run([*cmd_prefix, 'systemctl', 'set-property', '--runtime', '%s' % scope, 'CPUQuota=60%'],
+            # smartune runs as root; system scopes need no sudo.
+            result = subprocess.run(['systemctl', 'set-property', '--runtime', '%s' % scope, 'CPUQuota=60%'],
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
 
         for service in services:
             result = subprocess.run(['systemctl', '--user', 'set-property', '--runtime', '%s' % service, 'CPUQuota=60%'],
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
+
+    def _resolve_session_user(self) -> Optional[str]:
+        """Return the desktop user whose ``systemd --user`` session we target.
+
+        Under interactive ``sudo -E`` startup, ``SUDO_USER`` names the invoking
+        user.  Under the systemd service (``User=root``, no controlling tty)
+        ``SUDO_USER`` is unset and ``os.getlogin()`` raises ``OSError``, so fall
+        back to the owner of an active ``/run/user/<uid>`` runtime directory,
+        skipping root's own.  Returns ``None`` when no desktop session is found.
+        """
+        user = os.getenv('SUDO_USER')
+        if user:
+            return user
+        try:
+            return os.getlogin()
+        except OSError:
+            pass
+        try:
+            for entry in sorted(os.listdir('/run/user')):
+                if entry.isdigit() and int(entry) != 0:
+                    return pwd.getpwuid(int(entry)).pw_name
+        except (OSError, KeyError):
+            pass
+        return None
 
     def _is_system_service(self, unit_name: str) -> bool:
         """Return True if *unit_name* lives under /sys/fs/cgroup/system.slice.
@@ -268,28 +293,41 @@ class Controller:
         # Execute command with up to _MAX_RETRIES retries to handle transient dbus timeout issues
         _MAX_RETRIES = 3
         try:
-            dbus_address = app_utils.get_dbus_address()
-            if not dbus_address:
-                raise Exception("Failed to retrieve DBus session address")
-
-            if getattr(self.config, "vendor", "") == "generic":
-                # scope and system_service both use "sudo systemctl" (no --user);
-                # user-space .service units go through the D-Bus session bus.
-                cmd_base = (
-                    ['sudo', 'systemctl', 'set-property', '--runtime', matching_app]
-                    if unit_type in ('scope', 'system_service') else
-                    [
-                        'sudo', '-u', os.getenv('SUDO_USER') or os.getlogin(),
-                        f'DBUS_SESSION_BUS_ADDRESS={dbus_address}',
-                        'systemctl', '--user', 'set-property', '--runtime', matching_app
-                    ]
-                )
+            dbus_address = None
+            if getattr(self.config, "vendor", "") == "generic" and unit_type not in ('scope', 'system_service'):
+                # User-space .service unit: smartune is root, so drop to the
+                # desktop user to reach their `systemd --user` session bus.
+                session_user = self._resolve_session_user()
+                if not session_user:
+                    raise Exception("Cannot resolve desktop user for user-scope systemctl")
+                # Derive the DBus address from the *resolved* user's uid, not the
+                # current (root) uid, otherwise systemctl --user would target the
+                # wrong session bus (/run/user/0/bus).
+                try:
+                    session_uid = pwd.getpwnam(session_user).pw_uid
+                except KeyError:
+                    raise Exception(f"Cannot resolve uid for desktop user {session_user}")
+                dbus_address = app_utils.get_dbus_address(session_uid)
+                if not dbus_address:
+                    raise Exception("Failed to retrieve DBus session address")
+                cmd_base = [
+                    'sudo', '-u', session_user,
+                    f'DBUS_SESSION_BUS_ADDRESS={dbus_address}',
+                    'systemctl', '--user', 'set-property', '--runtime', matching_app
+                ]
             else:
-                cmd_base = (
-                    ['systemctl', 'set-property', '--runtime', matching_app]
-                )
+                # System scopes/services (and non-generic vendors): smartune
+                # already runs as root, so no sudo prefix is needed.
+                cmd_base = ['systemctl', 'set-property', '--runtime', matching_app]
 
             cmd = cmd_base + properties
+
+            # Merge the DBus address into the existing environment rather than
+            # replacing it, so PATH/locale (needed to resolve sudo/systemctl)
+            # are preserved.
+            run_env = os.environ.copy()
+            if dbus_address:
+                run_env["DBUS_SESSION_BUS_ADDRESS"] = dbus_address
 
             logger.debug(f"Executing command: {' '.join(cmd)}")
             for attempt in range(1, _MAX_RETRIES + 1):
@@ -300,7 +338,7 @@ class Controller:
                         stderr=subprocess.PIPE,
                         text=True,
                         check=True,
-                        env={"DBUS_SESSION_BUS_ADDRESS": dbus_address} if dbus_address else None
+                        env=run_env
                     )
                     logger.debug(f"Executed result: {result}")
                     return True

--- a/balancer/controller/cpu.py
+++ b/balancer/controller/cpu.py
@@ -4,8 +4,7 @@
 import os
 from controller.base import ControllerBase
 from utils.logger import logger
-from utils.app_utils import build_sudo_shell_redirect
-import subprocess # nosec
+from utils.app_utils import write_cgroup_file
 from config.config import b_config
 
 # Reserved
@@ -42,10 +41,9 @@ class CPUController(ControllerBase):
         try:
             path = os.path.join(self.get_full_path(cgroup), param)
             logger.debug(f"cpu set_parameter path = {path}")
-            cmd = build_sudo_shell_redirect(value, path)
-            subprocess.run(cmd, capture_output=True)
+            write_cgroup_file(value, path)
             return True
-        except (FileNotFoundError, PermissionError) as e:
+        except OSError as e:
             logger.error(f"Failed to set {param}={value}: {e}")
             return False
 

--- a/balancer/controller/governor.py
+++ b/balancer/controller/governor.py
@@ -14,8 +14,8 @@ class GovernorController:
 
     def __get_governor(self):
         try:
-            base_cmd = ["cpupower", "frequency-info", "-p"]
-            cmd = ["sudo", *base_cmd] if getattr(self.config, "vendor", "") == "generic" else base_cmd
+            # smartune runs as root; reading cpupower info needs no sudo.
+            cmd = ["cpupower", "frequency-info", "-p"]
             result = subprocess.run(
                 cmd,
                 capture_output = True,

--- a/balancer/controller/io.py
+++ b/balancer/controller/io.py
@@ -2,14 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-# [SECURITY REVIEW]: All subprocess calls in this module use list-based arguments 
-# with shell=False (default). No untrusted shell execution or string 
-# concatenation is performed. All inputs are internally validated.
-import subprocess # nosec
+import re
+import subprocess
 from typing import Optional, List, Dict, Union
 from config.config import b_config
 from utils.logger import logger
-from utils.app_utils import build_sudo_shell_redirect
+from utils.app_utils import write_cgroup_file
+
+# A cgroup/unit name as it appears on disk: scope/service/slice names, digits,
+# and the delimiters systemd uses. Deliberately excludes '/', whitespace and
+# the glob metacharacters ('*', '?', '[') that `find -name` would interpret,
+# so a tainted id can neither traverse paths nor widen the match.
+_CGROUP_ID_RE = re.compile(r'^[A-Za-z0-9._@:-]+$')
+
 
 class IOController:
     def __init__(self):
@@ -31,15 +36,14 @@ class IOController:
             logger.error(f"Failed to get active user slices: {e}")
         return "0"
 
-    def _run_cmd(self, cmd, check: bool = True, log_on_fail: bool = True) -> bool:
-        """Execute a shell command and return True on success."""
+    def _write_cgroup_file(self, content: str, target_file: str, log_on_fail: bool = True) -> bool:
+        """Write one cgroup control value and return whether it succeeded."""
         try:
-            subprocess.run(cmd, shell=False, check=check, capture_output=True)
+            write_cgroup_file(content, target_file)
             return True
-        except subprocess.CalledProcessError as e:
+        except OSError as error:
             if log_on_fail:
-                cmd_str = ' '.join(cmd) if isinstance(cmd, list) else cmd
-                logger.error(f"Command failed: {cmd_str}\nError: {e.stderr.decode().strip()}")
+                logger.error("Failed to write cgroup file %s: %s", target_file, error)
             return False
 
     def _check_file_exists(self, path: str) -> bool:
@@ -66,8 +70,7 @@ class IOController:
                 success = False
                 continue
 
-            cmd = build_sudo_shell_redirect("+io", path)
-            if not self._run_cmd(cmd):
+            if not self._write_cgroup_file("+io", path):
                 success = False
 
         return success
@@ -167,9 +170,8 @@ class IOController:
                     if 'io' in f.read().split():
                         continue
 
-                cmd = build_sudo_shell_redirect("+io", control_file)
                 logger.info(f"Enabling IO controller at {control_file}")
-                if not self._run_cmd(cmd):
+                if not self._write_cgroup_file("+io", control_file):
                     logger.info(f"Failed to enable IO at {control_file}")
                     return False
 
@@ -181,6 +183,11 @@ class IOController:
 
     def _get_full_cgroup_path(self, cgroup_id: str, file: str) -> Optional[str]:
         """Locate the full cgroup directory path for cgroup_id and return the path to file."""
+        if not cgroup_id or not _CGROUP_ID_RE.match(cgroup_id):
+            # Reject anything that isn't a plain unit name before it reaches
+            # `find -name` (glob) or gets joined into a write path.
+            logger.warning(f"Rejecting invalid cgroup_id for path lookup: {cgroup_id!r}")
+            return None
         try:
             result = subprocess.run(
                 ["find", self.cgroup_mount, "-name", cgroup_id, "-type", "d"],
@@ -275,7 +282,6 @@ class IOController:
                     success = False
                     continue
 
-                cmd = build_sudo_shell_redirect(f"{disk_id} {limit_str}", io_max_path)
                 logger.info(f"Setting IO limits for cgroup: {cgroup_id} in disk {disk_name}({disk_id}): {limit_str}")
 
                 # Any `systemctl set-property` elsewhere (e.g. CPU/mem restore) can
@@ -284,8 +290,10 @@ class IOController:
                 # has no IO constraints once CPUQuota=/MemoryHigh= are cleared. The
                 # write then returns EACCES even though our pre-flight check passed.
                 # Re-run _ensure_io_enabled (re-adds +io) and retry once.
-                if not self._run_cmd(cmd, log_on_fail=False):
-                    if self._ensure_io_enabled(io_max_path) and self._run_cmd(cmd):
+                if not self._write_cgroup_file(f"{disk_id} {limit_str}", io_max_path, log_on_fail=False):
+                    if self._ensure_io_enabled(io_max_path) and self._write_cgroup_file(
+                        f"{disk_id} {limit_str}", io_max_path
+                    ):
                         continue
                     logger.error(
                         f"Failed to write io.max for cgroup {cgroup_id} (disk {disk_name}) "
@@ -341,8 +349,7 @@ class IOController:
             return False
 
         logger.info(f"Setting IO weight to {weight} for cgroup {cgroup_id}")
-        cmd = build_sudo_shell_redirect(str(weight), io_weight_path)
-        return self._run_cmd(cmd)
+        return self._write_cgroup_file(str(weight), io_weight_path)
 
     def get_current_io_limits(self, cgroup_id: str) -> Optional[tuple[int, int, int, int]]:
         """

--- a/balancer/controller/memory.py
+++ b/balancer/controller/memory.py
@@ -3,13 +3,10 @@
 
 import os
 from controller.base import ControllerBase
-# [SECURITY REVIEW]: All subprocess calls in this module use list-based arguments 
-# with shell=False (default). No untrusted shell execution or string 
-# concatenation is performed. All inputs are internally validated.
-import subprocess # nosec
+import subprocess
 
 from utils.logger import logger
-from utils.app_utils import build_sudo_cmd, build_sudo_shell_redirect
+from utils.app_utils import write_cgroup_file
 from config.config import b_config
 
 # Reserved
@@ -24,11 +21,11 @@ class MemoryController(ControllerBase):
     def set_managed_oom_pressure(self, user_service: str = "user@1000.service", oom_pressure: str = "auto") -> bool:
         """Control of systemd OOM will take over in the Balancer, so set the default value from kill to auto"""
         try:
-            cmd_base = [
+            # smartune runs as root, so call systemctl directly (no sudo prefix).
+            cmd = [
                 'systemctl', 'set-property', '--runtime',
                 user_service, f'ManagedOOMMemoryPressure={oom_pressure}'
             ]
-            cmd = build_sudo_cmd(cmd_base)
 
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
             if result.returncode == 0:
@@ -43,10 +40,9 @@ class MemoryController(ControllerBase):
         try:
             path = os.path.join(self.get_full_path(cgroup), param)
             logger.debug(f"mem set_parameter path = {path}")
-            cmd = build_sudo_shell_redirect(value, path)
-            subprocess.run(cmd, capture_output=True)
+            write_cgroup_file(value, path)
             return True
-        except (FileNotFoundError, PermissionError) as e:
+        except OSError as e:
             logger.error(f"Failed to set {param}={value}: {e}")
             return False
 

--- a/utils/app_utils.py
+++ b/utils/app_utils.py
@@ -27,30 +27,31 @@ _controlled_apps_snapshot: Optional[List[Dict[str, Any]]] = None
 _controlled_apps_epoch: int = -1
 
 
-def build_sudo_cmd(base_cmd: List[str]) -> List[str]:
-    """
-    Build command with or without sudo based on vendor configuration.
-
-    :param base_cmd: The base command as a list
-    :return: Command list with sudo prepended if vendor is "generic", otherwise original command
-    """
-    if getattr(b_config, "vendor", "generic") == "generic":
-        return ["sudo"] + base_cmd
-    return base_cmd
+def _default_cgroup_root() -> str:
+    """The configured cgroup mount, defaulting to the standard v2 location."""
+    return getattr(b_config, "cgroup_mount", None) or "/sys/fs/cgroup"
 
 
-def build_sudo_shell_redirect(content: str, target_file: str) -> List[str]:
-    """
-    Build a shell redirection command with or without sudo based on vendor configuration.
+def write_cgroup_file(content: str, target_file: str, allowed_roots=None) -> None:
+    """Write *content* to a cgroup control file without invoking a shell.
 
-    :param content: The content to write (e.g., "+io", "100")
-    :param target_file: The target file path
-    :return: Command list for shell redirection
+    The real path of *target_file* (after resolving symlinks and ``..``) must
+    fall inside one of *allowed_roots* -- the configured cgroup mount by
+    default -- otherwise a ``PermissionError`` is raised and nothing is written.
+
+    This is defence-in-depth: today every caller passes an internally-built
+    path, but because this process runs as root the guard makes sure a future
+    caller that forwards a tainted path (``../../etc/...``) cannot clobber an
+    arbitrary file. ``PermissionError`` subclasses ``OSError``, so callers that
+    already treat a failed write as an ``OSError`` handle a refusal unchanged.
     """
-    shell_cmd = f"echo '{content}' > {target_file}"
-    if getattr(b_config, "vendor", "generic") == "generic":
-        return ["sudo", "sh", "-c", shell_cmd]
-    return ["sh", "-c", shell_cmd]
+    roots = tuple(allowed_roots) if allowed_roots is not None else (_default_cgroup_root(),)
+    real_path = os.path.realpath(target_file)
+    real_roots = [os.path.realpath(root) for root in roots]
+    if not any(real_path == root or real_path.startswith(root + os.sep) for root in real_roots):
+        raise PermissionError(f"Refusing to write outside {roots}: {target_file!r} -> {real_path}")
+    with open(real_path, "w", encoding="utf-8") as target:
+        target.write(f"{content}\n")
 
 class ClientCallbackManager:
     """Manages global state and operations for client-side callbacks."""
@@ -740,16 +741,13 @@ def adjust_oom_priority(
                 target_value = "-1000"
                 action = "Setting"
 
-            # Update oom_score_adj
+            # Update oom_score_adj. smartune runs as root (see smartune.service),
+            # so write /proc/<pid>/oom_score_adj directly instead of shelling out
+            # to `sudo tee` -- same shell-free path as write_cgroup_file().
             logger.debug(f"{action} OOM priority for PID {pid} to {target_value}")
-            base_cmd = ["tee", oom_file]
-            cmd = ["sudo", *base_cmd] if getattr(b_config, "vendor", "") == "generic" else base_cmd
-            subprocess.run(
-                cmd,
-                input=target_value,
-                text=True,
-                check=True,
-            )
+            # oom_file is /proc/<pid>/oom_score_adj (pid comes from pgrep, so
+            # always numeric); allow the /proc tree for this one write.
+            write_cgroup_file(str(target_value), oom_file, allowed_roots=("/proc",))
 
         _update_app_oom_score_adj(app_id, int(target_value))
         logger.info(f"OOM priority updated for {app_name} (PID(s): {', '.join(pids)})")
@@ -981,19 +979,28 @@ def get_app_resource_usage(app_id: str, app_name: str) -> dict:
         return {}
 
 
-def get_dbus_address():
-    """Dynamically retrieve the current user's DBus session bus address."""
-    uid = os.getuid()
+def get_dbus_address(uid=None):
+    """Dynamically retrieve the DBus session bus address for ``uid``.
+
+    When ``uid`` is None the current process uid is used. Callers that run as
+    root but need to reach a desktop user's ``systemd --user`` session must pass
+    that user's uid, otherwise the root session bus (``/run/user/0/bus``) is
+    resolved and ``systemctl --user`` talks to the wrong session.
+    """
+    if uid is None:
+        uid = os.getuid()
 
     # Method 1: check the standard socket path
     standard_path = f"/run/user/{uid}/bus"
     if os.path.exists(standard_path):
         return f"unix:path={standard_path}"
 
-    # Method 2: retrieve from process environment
+    # Method 2: retrieve from a process owned by the target uid
     try:
-        for proc in psutil.process_iter(['environ']):
+        for proc in psutil.process_iter(['uids', 'environ']):
             try:
+                if proc.uids().real != uid:
+                    continue
                 env = proc.environ()
                 if 'DBUS_SESSION_BUS_ADDRESS' in env:
                     return env['DBUS_SESSION_BUS_ADDRESS']


### PR DESCRIPTION
- Replace shell-based cgroup file writes with guarded direct file I/O.
- Validate cgroup IDs to prevent path traversal and wildcard expansion.
- Remove redundant sudo tee when updating oom_score_adj.
- Use direct system-level systemctl commands for root-run operations.